### PR TITLE
release(0.5.0): 정규 업데이트

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)를 기반으로 하며,
 이 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 준수합니다.
 
+## [0.5.0] - 2025-01-22
+
+### Added
+
+* 매치 세션 및 MMR 시스템 전체 구현 (#23, #24, #25, #26)
+  * Domain 레이어: `MatchSession` Aggregate Root, `MatchResult`, `PlayerResult` 엔티티 및 값 객체, `EloRatingCalculator` Domain 서비스, `PlayerMMR` 엔티티 구현
+  * Application 레이어: `StartMatchUseCase`, `EndMatchUseCase`, `UpdatePlayerMMRUseCase`, `BulkUpdatePlayerMMRUseCase` 구현, Port 인터페이스 (`IMatchSessionRepository`, `IPlayerMMRRepository`)
+  * Infrastructure 레이어: `EfMatchSessionRepository`, `EfPlayerMMRRepository` 구현, `FpsDbContext` EF Core DbContext 생성
+  * API 레이어: `POST /api/fps/matches/{matchId}/start`, `POST /api/fps/matches/{matchId}/end` 엔드포인트 구현
+  * Elo 레이팅 시스템 기반 MMR 계산 알고리즘
+  * 매치 세션 라이프사이클 관리 (Matched → InProgress → Finished)
+  * 매치 종료 시 자동 MMR 업데이트 트리거
+  * EF Core 엔티티 매핑 설정 (Fluent API)
+  * 단위 테스트 및 통합 테스트 작성 (모든 테스트 통과)
+
 ## [0.4.0] - 2025-01-22
 
 ### Added

--- a/src/Services/FpsServer/FpsServer.Api/Controllers/MatchController.cs
+++ b/src/Services/FpsServer/FpsServer.Api/Controllers/MatchController.cs
@@ -1,0 +1,175 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Application.MatchSession.UseCases;
+using FpsServer.Application.MMR.DTOs;
+using FpsServer.Application.MMR.UseCases;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.Matchmaking;
+using FpsServer.Domain.MatchSession.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FpsServer.Api.Controllers;
+
+/// <summary>
+/// 매치 세션 API 컨트롤러
+/// </summary>
+[ApiController]
+[Route("api/fps/matches")]
+public class MatchController : ControllerBase
+{
+    private readonly StartMatchUseCase _startMatchUseCase;
+    private readonly EndMatchUseCase _endMatchUseCase;
+    private readonly UpdatePlayerMMRUseCase _updatePlayerMMRUseCase;
+    private readonly IPlayerMMRRepository _playerMMRRepository;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    public MatchController(
+        StartMatchUseCase startMatchUseCase,
+        EndMatchUseCase endMatchUseCase,
+        UpdatePlayerMMRUseCase updatePlayerMMRUseCase,
+        IPlayerMMRRepository playerMMRRepository)
+    {
+        _startMatchUseCase = startMatchUseCase ?? throw new ArgumentNullException(nameof(startMatchUseCase));
+        _endMatchUseCase = endMatchUseCase ?? throw new ArgumentNullException(nameof(endMatchUseCase));
+        _updatePlayerMMRUseCase = updatePlayerMMRUseCase ?? throw new ArgumentNullException(nameof(updatePlayerMMRUseCase));
+        _playerMMRRepository = playerMMRRepository ?? throw new ArgumentNullException(nameof(playerMMRRepository));
+    }
+    
+    /// <summary>
+    /// 매치 시작
+    /// </summary>
+    /// <param name="matchId">매치 ID</param>
+    /// <param name="request">매치 시작 요청</param>
+    /// <param name="gameMode">게임 모드 (쿼리 파라미터)</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 시작 응답</returns>
+    [HttpPost("{matchId}/start")]
+    [ProducesResponseType(typeof(StartMatchResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> StartMatch(
+        [FromRoute] Guid matchId,
+        [FromBody] StartMatchRequest request,
+        [FromQuery] MatchmakingMode gameMode = MatchmakingMode.Solo,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Route의 matchId와 Body의 MatchId 일치 확인
+            if (request.MatchId != matchId)
+            {
+                return BadRequest(new { error = "Route의 matchId와 Body의 MatchId가 일치하지 않습니다." });
+            }
+            
+            var response = await _startMatchUseCase.ExecuteAsync(request, gameMode, cancellationToken);
+            return Ok(response);
+        }
+        catch (MatchSessionNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (InvalidMatchSessionStateException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+    
+    /// <summary>
+    /// 매치 종료 (MMR 업데이트 자동 트리거)
+    /// </summary>
+    /// <param name="matchId">매치 ID</param>
+    /// <param name="request">매치 종료 요청</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 종료 응답</returns>
+    [HttpPost("{matchId}/end")]
+    [ProducesResponseType(typeof(EndMatchResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> EndMatch(
+        [FromRoute] Guid matchId,
+        [FromBody] EndMatchRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Route의 matchId와 Body의 MatchId 일치 확인
+            if (request.MatchId != matchId)
+            {
+                return BadRequest(new { error = "Route의 matchId와 Body의 MatchId가 일치하지 않습니다." });
+            }
+            
+            // 1. 매치 종료 처리
+            var endMatchResponse = await _endMatchUseCase.ExecuteAsync(request, cancellationToken);
+            
+            // 2. MMR 업데이트 (동기 호출)
+            await UpdatePlayerMMRsAsync(request, cancellationToken);
+            
+            return Ok(endMatchResponse);
+        }
+        catch (MatchSessionNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (InvalidMatchSessionStateException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+    
+    /// <summary>
+    /// 플레이어 MMR 업데이트 (매치 종료 후 자동 호출)
+    /// </summary>
+    /// <param name="request">매치 종료 요청</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    private async Task UpdatePlayerMMRsAsync(
+        EndMatchRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Results == null || !request.Results.Any())
+            return;
+        
+        // 1. 모든 플레이어의 현재 MMR 조회
+        var playerIds = request.Results.Select(r => r.PlayerId).ToList();
+        var playerMMRs = await _playerMMRRepository.FindMultipleByPlayerIdsAsync(playerIds, cancellationToken);
+        
+        // 2. 플레이어별 MMR 맵 생성 (없으면 기본값 1500)
+        var playerMMRMap = playerMMRs.ToDictionary(
+            pm => pm.PlayerId,
+            pm => pm.CurrentMMR.Value);
+        
+        foreach (var playerId in playerIds)
+        {
+            if (!playerMMRMap.ContainsKey(playerId))
+                playerMMRMap[playerId] = 1500; // 기본 MMR
+        }
+        
+        // 3. 승리 팀과 패배 팀 구분
+        var winners = request.Results.Where(r => r.IsWinner).Select(r => r.PlayerId).ToList();
+        var losers = request.Results.Where(r => !r.IsWinner).Select(r => r.PlayerId).ToList();
+        
+        // 4. 각 플레이어에 대해 상대방 평균 MMR 계산 및 업데이트
+        foreach (var result in request.Results)
+        {
+            // 상대방 팀의 평균 MMR 계산
+            var opponentTeam = result.IsWinner ? losers : winners;
+            var opponentAverageMMR = opponentTeam.Any()
+                ? (int)opponentTeam.Average(pid => playerMMRMap[pid])
+                : 1500; // 상대방이 없으면 기본값
+            
+            // MMR 업데이트 요청 생성
+            var updateMMRRequest = new UpdateMMRRequest
+            {
+                PlayerId = result.PlayerId,
+                MatchId = request.MatchId,
+                IsWinner = result.IsWinner,
+                OpponentAverageMMR = opponentAverageMMR,
+                KFactor = 32 // 기본 K 값
+            };
+            
+            // MMR 업데이트 실행
+            await _updatePlayerMMRUseCase.ExecuteAsync(updateMMRRequest, cancellationToken);
+        }
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Api/Program.cs
+++ b/src/Services/FpsServer/FpsServer.Api/Program.cs
@@ -3,6 +3,8 @@ using FpsServer.Application.Matchmaking.UseCases;
 using FpsServer.Application.Chat.UseCases;
 using FpsServer.Infrastructure.Matchmaking;
 using FpsServer.Infrastructure.Chat;
+using FpsServer.Infrastructure.MatchSession;
+using FpsServer.Infrastructure.MMR;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.SignalR;
@@ -17,18 +19,24 @@ builder.Services.AddSignalR();
 
 // FluentValidation 등록
 builder.Services.AddValidatorsFromAssemblyContaining<JoinMatchmakingRequestValidator>();
+builder.Services.AddValidatorsFromAssemblyContaining<StartMatchRequestValidator>();
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddFluentValidationClientsideAdapters();
 
 // Infrastructure 레이어 서비스 등록
 builder.Services.AddMatchmakingInfrastructure();
 builder.Services.AddChatInfrastructure();
+builder.Services.AddMatchSessionInfrastructure();
+builder.Services.AddMMRInfrastructure();
 
 // UseCase 등록
 builder.Services.AddScoped<JoinMatchmakingQueueUseCase>();
 builder.Services.AddScoped<CancelMatchmakingUseCase>();
 builder.Services.AddScoped<SendMessageUseCase>();
 builder.Services.AddScoped<GetChatHistoryUseCase>();
+builder.Services.AddScoped<FpsServer.Application.MatchSession.UseCases.StartMatchUseCase>();
+builder.Services.AddScoped<FpsServer.Application.MatchSession.UseCases.EndMatchUseCase>();
+builder.Services.AddScoped<FpsServer.Application.MMR.UseCases.UpdatePlayerMMRUseCase>();
 
 // CORS 설정 (로컬 테스트용)
 builder.Services.AddCors(options =>

--- a/src/Services/FpsServer/FpsServer.Api/Validators/EndMatchRequestValidator.cs
+++ b/src/Services/FpsServer/FpsServer.Api/Validators/EndMatchRequestValidator.cs
@@ -1,0 +1,49 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FluentValidation;
+
+namespace FpsServer.Api.Validators;
+
+/// <summary>
+/// EndMatchRequest 입력 검증
+/// </summary>
+public class EndMatchRequestValidator : AbstractValidator<EndMatchRequest>
+{
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    public EndMatchRequestValidator()
+    {
+        RuleFor(x => x.MatchId)
+            .NotEmpty()
+            .WithMessage("MatchId는 필수입니다.");
+        
+        RuleFor(x => x.Results)
+            .NotNull()
+            .WithMessage("Results는 필수입니다.")
+            .NotEmpty()
+            .WithMessage("Results는 최소 1명 이상이어야 합니다.");
+        
+        RuleForEach(x => x.Results)
+            .SetValidator(new PlayerResultDtoValidator());
+    }
+}
+
+/// <summary>
+/// PlayerResultDto 입력 검증
+/// </summary>
+public class PlayerResultDtoValidator : AbstractValidator<PlayerResultDto>
+{
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    public PlayerResultDtoValidator()
+    {
+        RuleFor(x => x.PlayerId)
+            .NotEmpty()
+            .WithMessage("PlayerId는 필수입니다.");
+        
+        // Score는 선택 사항이므로 검증하지 않음
+        // IsWinner는 bool이므로 자동 검증됨
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Api/Validators/StartMatchRequestValidator.cs
+++ b/src/Services/FpsServer/FpsServer.Api/Validators/StartMatchRequestValidator.cs
@@ -1,0 +1,31 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FluentValidation;
+
+namespace FpsServer.Api.Validators;
+
+/// <summary>
+/// StartMatchRequest 입력 검증
+/// </summary>
+public class StartMatchRequestValidator : AbstractValidator<StartMatchRequest>
+{
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    public StartMatchRequestValidator()
+    {
+        RuleFor(x => x.MatchId)
+            .NotEmpty()
+            .WithMessage("MatchId는 필수입니다.");
+        
+        RuleFor(x => x.PlayerIds)
+            .NotNull()
+            .WithMessage("PlayerIds는 필수입니다.")
+            .NotEmpty()
+            .WithMessage("PlayerIds는 최소 1명 이상이어야 합니다.");
+        
+        RuleForEach(x => x.PlayerIds)
+            .NotEmpty()
+            .WithMessage("PlayerId는 빈 값일 수 없습니다.");
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/BulkUpdateMMRRequest.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/BulkUpdateMMRRequest.cs
@@ -1,0 +1,44 @@
+namespace FpsServer.Application.MMR.DTOs;
+
+/// <summary>
+/// 플레이어별 MMR 업데이트 정보
+/// </summary>
+public record PlayerMMRUpdateInfo
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public required Guid PlayerId { get; init; }
+    
+    /// <summary>
+    /// 승리 여부 (true: 승리, false: 패배)
+    /// </summary>
+    public required bool IsWinner { get; init; }
+    
+    /// <summary>
+    /// 상대방 평균 MMR (팀 매칭의 경우 팀 평균)
+    /// </summary>
+    public required int OpponentAverageMMR { get; init; }
+}
+
+/// <summary>
+/// 여러 플레이어 MMR 일괄 업데이트 요청 DTO
+/// </summary>
+public record BulkUpdateMMRRequest
+{
+    /// <summary>
+    /// 매치 ID
+    /// </summary>
+    public required Guid MatchId { get; init; }
+    
+    /// <summary>
+    /// 플레이어별 MMR 업데이트 정보 목록
+    /// </summary>
+    public required IReadOnlyList<PlayerMMRUpdateInfo> PlayerUpdates { get; init; }
+    
+    /// <summary>
+    /// K 값 (기본값: 32, 조정 가능)
+    /// </summary>
+    public int KFactor { get; init; } = 32;
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/BulkUpdateMMRResponse.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/BulkUpdateMMRResponse.cs
@@ -1,0 +1,13 @@
+namespace FpsServer.Application.MMR.DTOs;
+
+/// <summary>
+/// 여러 플레이어 MMR 일괄 업데이트 응답 DTO
+/// </summary>
+public record BulkUpdateMMRResponse
+{
+    /// <summary>
+    /// 업데이트된 플레이어별 결과 목록
+    /// </summary>
+    public required IReadOnlyList<UpdateMMRResponse> Results { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/UpdateMMRRequest.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/UpdateMMRRequest.cs
@@ -1,0 +1,33 @@
+namespace FpsServer.Application.MMR.DTOs;
+
+/// <summary>
+/// MMR 업데이트 요청 DTO
+/// </summary>
+public record UpdateMMRRequest
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public required Guid PlayerId { get; init; }
+    
+    /// <summary>
+    /// 매치 ID
+    /// </summary>
+    public required Guid MatchId { get; init; }
+    
+    /// <summary>
+    /// 승리 여부 (true: 승리, false: 패배)
+    /// </summary>
+    public required bool IsWinner { get; init; }
+    
+    /// <summary>
+    /// 상대방 평균 MMR (팀 매칭의 경우 팀 평균)
+    /// </summary>
+    public required int OpponentAverageMMR { get; init; }
+    
+    /// <summary>
+    /// K 값 (기본값: 32, 조정 가능)
+    /// </summary>
+    public int KFactor { get; init; } = 32;
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/UpdateMMRResponse.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/DTOs/UpdateMMRResponse.cs
@@ -1,0 +1,23 @@
+namespace FpsServer.Application.MMR.DTOs;
+
+/// <summary>
+/// MMR 업데이트 응답 DTO
+/// </summary>
+public record UpdateMMRResponse
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public required Guid PlayerId { get; init; }
+    
+    /// <summary>
+    /// 이전 MMR 값
+    /// </summary>
+    public required int OldMMR { get; init; }
+    
+    /// <summary>
+    /// 새로운 MMR 값
+    /// </summary>
+    public required int NewMMR { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/Mappers/MMRMapper.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/Mappers/MMRMapper.cs
@@ -1,0 +1,41 @@
+using FpsServer.Application.MMR.DTOs;
+using FpsServer.Domain.MMR;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+
+namespace FpsServer.Application.MMR.Mappers;
+
+/// <summary>
+/// MMR DTO ↔ Domain 변환 Mapper
+/// </summary>
+public static class MMRMapper
+{
+    /// <summary>
+    /// UpdateMMRRequest → DomainMMR 변환 (상대방 평균 MMR)
+    /// </summary>
+    public static DomainMMR ToDomainMMR(UpdateMMRRequest request)
+    {
+        return new DomainMMR(request.OpponentAverageMMR);
+    }
+    
+    /// <summary>
+    /// PlayerMMR → UpdateMMRResponse 변환
+    /// </summary>
+    public static UpdateMMRResponse ToUpdateMMRResponse(PlayerMMR playerMMR, int oldMMR)
+    {
+        return new UpdateMMRResponse
+        {
+            PlayerId = playerMMR.PlayerId,
+            OldMMR = oldMMR,
+            NewMMR = playerMMR.CurrentMMR.Value
+        };
+    }
+    
+    /// <summary>
+    /// PlayerMMRUpdateInfo → DomainMMR 변환 (상대방 평균 MMR)
+    /// </summary>
+    public static DomainMMR ToDomainMMR(PlayerMMRUpdateInfo updateInfo)
+    {
+        return new DomainMMR(updateInfo.OpponentAverageMMR);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/Ports/IPlayerMMRRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/Ports/IPlayerMMRRepository.cs
@@ -1,0 +1,47 @@
+using FpsServer.Domain.MMR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FpsServer.Application.MMR.Ports;
+
+/// <summary>
+/// 플레이어 MMR 저장소 Port 인터페이스
+/// Infrastructure 레이어에서 구현됩니다 (예: EF Core).
+/// </summary>
+public interface IPlayerMMRRepository
+{
+    /// <summary>
+    /// 플레이어 ID로 MMR 조회
+    /// </summary>
+    /// <param name="playerId">플레이어 ID</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>조회된 플레이어 MMR 또는 null</returns>
+    Task<PlayerMMR?> FindByPlayerIdAsync(Guid playerId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 여러 플레이어 ID로 MMR 목록 조회
+    /// </summary>
+    /// <param name="playerIds">플레이어 ID 목록</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>조회된 플레이어 MMR 목록</returns>
+    Task<IReadOnlyList<PlayerMMR>> FindMultipleByPlayerIdsAsync(
+        IReadOnlyList<Guid> playerIds,
+        CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 플레이어 MMR 생성 또는 업데이트
+    /// </summary>
+    /// <param name="playerMMR">플레이어 MMR</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    Task SaveAsync(PlayerMMR playerMMR, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 여러 플레이어 MMR 일괄 저장
+    /// </summary>
+    /// <param name="playerMMRs">플레이어 MMR 목록</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    Task SaveMultipleAsync(
+        IReadOnlyList<PlayerMMR> playerMMRs,
+        CancellationToken cancellationToken = default);
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/UseCases/BulkUpdatePlayerMMRUseCase.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/UseCases/BulkUpdatePlayerMMRUseCase.cs
@@ -1,0 +1,95 @@
+using FpsServer.Application.MMR.DTOs;
+using FpsServer.Application.MMR.Mappers;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.MMR;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FpsServer.Application.MMR.UseCases;
+
+/// <summary>
+/// 여러 플레이어 MMR 일괄 업데이트 유스케이스
+/// 매치 종료 후 여러 플레이어의 MMR을 동시에 계산하고 업데이트합니다.
+/// </summary>
+public class BulkUpdatePlayerMMRUseCase
+{
+    private readonly IPlayerMMRRepository _repository;
+    private readonly IMMRCalculator _calculator;
+
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="repository">플레이어 MMR 저장소</param>
+    /// <param name="calculator">MMR 계산기</param>
+    public BulkUpdatePlayerMMRUseCase(
+        IPlayerMMRRepository repository,
+        IMMRCalculator calculator)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _calculator = calculator ?? throw new ArgumentNullException(nameof(calculator));
+    }
+
+    /// <summary>
+    /// 여러 플레이어 MMR 일괄 업데이트를 처리합니다.
+    /// </summary>
+    /// <param name="request">일괄 MMR 업데이트 요청</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>일괄 MMR 업데이트 응답</returns>
+    public async Task<BulkUpdateMMRResponse> ExecuteAsync(
+        BulkUpdateMMRRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. 모든 플레이어 ID 추출
+        var playerIds = request.PlayerUpdates.Select(p => p.PlayerId).ToList();
+        
+        // 2. 기존 플레이어 MMR 목록 조회
+        var existingPlayerMMRs = await _repository.FindMultipleByPlayerIdsAsync(playerIds, cancellationToken);
+        var playerMMRMap = existingPlayerMMRs.ToDictionary(p => p.PlayerId);
+        
+        // 3. 각 플레이어별로 MMR 계산 및 업데이트
+        var updatedPlayerMMRs = new List<PlayerMMR>();
+        var results = new List<UpdateMMRResponse>();
+        
+        foreach (var updateInfo in request.PlayerUpdates)
+        {
+            // 기존 MMR 조회 또는 생성
+            if (!playerMMRMap.TryGetValue(updateInfo.PlayerId, out var playerMMR))
+            {
+                playerMMR = new PlayerMMR(updateInfo.PlayerId);
+                playerMMRMap[updateInfo.PlayerId] = playerMMR;
+            }
+            
+            var oldMMR = playerMMR.CurrentMMR.Value;
+            
+            // 상대방 평균 MMR 값 객체 생성
+            var opponentAverageMMR = MMRMapper.ToDomainMMR(updateInfo);
+            
+            // 실제 점수 계산 (1.0: 승리, 0.0: 패배)
+            var actualScore = updateInfo.IsWinner ? 1.0 : 0.0;
+            
+            // 새로운 MMR 계산
+            var newMMR = _calculator.CalculateNewMMR(
+                playerMMR.CurrentMMR,
+                opponentAverageMMR,
+                actualScore,
+                request.KFactor);
+            
+            // MMR 업데이트
+            playerMMR.UpdateMMR(newMMR);
+            
+            updatedPlayerMMRs.Add(playerMMR);
+            results.Add(MMRMapper.ToUpdateMMRResponse(playerMMR, oldMMR));
+        }
+        
+        // 4. 일괄 저장
+        await _repository.SaveMultipleAsync(updatedPlayerMMRs, cancellationToken);
+        
+        // 5. 응답 반환
+        return new BulkUpdateMMRResponse
+        {
+            Results = results
+        };
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MMR/UseCases/UpdatePlayerMMRUseCase.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MMR/UseCases/UpdatePlayerMMRUseCase.cs
@@ -1,0 +1,77 @@
+using FpsServer.Application.MMR.DTOs;
+using FpsServer.Application.MMR.Mappers;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.MMR;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FpsServer.Application.MMR.UseCases;
+
+/// <summary>
+/// 플레이어 MMR 업데이트 유스케이스
+/// 매치 종료 후 승/패 결과에 따라 플레이어의 MMR을 계산하고 업데이트합니다.
+/// </summary>
+public class UpdatePlayerMMRUseCase
+{
+    private readonly IPlayerMMRRepository _repository;
+    private readonly IMMRCalculator _calculator;
+
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="repository">플레이어 MMR 저장소</param>
+    /// <param name="calculator">MMR 계산기</param>
+    public UpdatePlayerMMRUseCase(
+        IPlayerMMRRepository repository,
+        IMMRCalculator calculator)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _calculator = calculator ?? throw new ArgumentNullException(nameof(calculator));
+    }
+
+    /// <summary>
+    /// 플레이어 MMR 업데이트를 처리합니다.
+    /// </summary>
+    /// <param name="request">MMR 업데이트 요청</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>MMR 업데이트 응답</returns>
+    public async Task<UpdateMMRResponse> ExecuteAsync(
+        UpdateMMRRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. 기존 플레이어 MMR 조회 또는 생성
+        var playerMMR = await _repository.FindByPlayerIdAsync(request.PlayerId, cancellationToken);
+        
+        if (playerMMR == null)
+        {
+            // 플레이어가 없으면 초기 MMR로 생성
+            playerMMR = new PlayerMMR(request.PlayerId);
+        }
+        
+        var oldMMR = playerMMR.CurrentMMR.Value;
+        
+        // 2. 상대방 평균 MMR 값 객체 생성
+        var opponentAverageMMR = MMRMapper.ToDomainMMR(request);
+        
+        // 3. 실제 점수 계산 (1.0: 승리, 0.0: 패배)
+        var actualScore = request.IsWinner ? 1.0 : 0.0;
+        
+        // 4. 새로운 MMR 계산
+        var newMMR = _calculator.CalculateNewMMR(
+            playerMMR.CurrentMMR,
+            opponentAverageMMR,
+            actualScore,
+            request.KFactor);
+        
+        // 5. MMR 업데이트
+        playerMMR.UpdateMMR(newMMR);
+        
+        // 6. 저장
+        await _repository.SaveAsync(playerMMR, cancellationToken);
+        
+        // 7. 응답 반환
+        return MMRMapper.ToUpdateMMRResponse(playerMMR, oldMMR);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/EndMatchRequest.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/EndMatchRequest.cs
@@ -1,0 +1,44 @@
+namespace FpsServer.Application.MatchSession.DTOs;
+
+/// <summary>
+/// 매치 종료 요청 DTO
+/// </summary>
+public record EndMatchRequest
+{
+    /// <summary>
+    /// 매치 ID
+    /// </summary>
+    public required Guid MatchId { get; init; }
+    
+    /// <summary>
+    /// 플레이어 결과 목록
+    /// </summary>
+    public required IReadOnlyList<PlayerResultDto> Results { get; init; }
+    
+    /// <summary>
+    /// 승리 팀/플레이어 ID (선택적)
+    /// </summary>
+    public Guid? WinnerId { get; init; }
+}
+
+/// <summary>
+/// 플레이어 결과 DTO
+/// </summary>
+public record PlayerResultDto
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public required Guid PlayerId { get; init; }
+    
+    /// <summary>
+    /// 승리 여부
+    /// </summary>
+    public required bool IsWinner { get; init; }
+    
+    /// <summary>
+    /// 점수 (선택적)
+    /// </summary>
+    public int? Score { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/EndMatchResponse.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/EndMatchResponse.cs
@@ -1,0 +1,20 @@
+using FpsServer.Domain.MatchSession;
+
+namespace FpsServer.Application.MatchSession.DTOs;
+
+/// <summary>
+/// 매치 종료 응답 DTO
+/// </summary>
+public record EndMatchResponse
+{
+    /// <summary>
+    /// 세션 ID
+    /// </summary>
+    public required Guid SessionId { get; init; }
+    
+    /// <summary>
+    /// 최종 상태
+    /// </summary>
+    public required MatchStatus FinalStatus { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/StartMatchRequest.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/StartMatchRequest.cs
@@ -1,0 +1,18 @@
+namespace FpsServer.Application.MatchSession.DTOs;
+
+/// <summary>
+/// 매치 시작 요청 DTO
+/// </summary>
+public record StartMatchRequest
+{
+    /// <summary>
+    /// 매치 ID
+    /// </summary>
+    public required Guid MatchId { get; init; }
+    
+    /// <summary>
+    /// 플레이어 ID 목록
+    /// </summary>
+    public required IReadOnlyList<Guid> PlayerIds { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/StartMatchResponse.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/DTOs/StartMatchResponse.cs
@@ -1,0 +1,20 @@
+using FpsServer.Domain.MatchSession;
+
+namespace FpsServer.Application.MatchSession.DTOs;
+
+/// <summary>
+/// 매치 시작 응답 DTO
+/// </summary>
+public record StartMatchResponse
+{
+    /// <summary>
+    /// 세션 ID
+    /// </summary>
+    public required Guid SessionId { get; init; }
+    
+    /// <summary>
+    /// 세션 상태
+    /// </summary>
+    public required MatchStatus Status { get; init; }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/Mappers/MatchSessionMapper.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/Mappers/MatchSessionMapper.cs
@@ -1,0 +1,56 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Domain.Matchmaking;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession;
+
+namespace FpsServer.Application.MatchSession.Mappers;
+
+/// <summary>
+/// 매치 세션 DTO ↔ Domain 변환 Mapper
+/// </summary>
+public static class MatchSessionMapper
+{
+    /// <summary>
+    /// StartMatchRequest → Domain 변환 (MatchSession 생성)
+    /// </summary>
+    public static DomainMatchSession ToDomain(StartMatchRequest request, MatchmakingMode gameMode)
+    {
+        return new DomainMatchSession(request.MatchId, request.PlayerIds, gameMode);
+    }
+    
+    /// <summary>
+    /// MatchSession → StartMatchResponse 변환
+    /// </summary>
+    public static StartMatchResponse ToStartResponse(DomainMatchSession session)
+    {
+        return new StartMatchResponse
+        {
+            SessionId = session.SessionId,
+            Status = session.Status
+        };
+    }
+    
+    /// <summary>
+    /// EndMatchRequest → MatchResult 변환
+    /// </summary>
+    public static MatchResult ToDomain(EndMatchRequest request)
+    {
+        var playerResults = request.Results.Select(r => 
+            new PlayerResult(r.PlayerId, r.IsWinner, r.Score)).ToList();
+        
+        return new MatchResult(request.MatchId, playerResults, request.WinnerId);
+    }
+    
+    /// <summary>
+    /// MatchSession → EndMatchResponse 변환
+    /// </summary>
+    public static EndMatchResponse ToEndResponse(DomainMatchSession session)
+    {
+        return new EndMatchResponse
+        {
+            SessionId = session.SessionId,
+            FinalStatus = session.Status
+        };
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/Ports/IMatchSessionRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/Ports/IMatchSessionRepository.cs
@@ -1,0 +1,41 @@
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+
+namespace FpsServer.Application.MatchSession.Ports;
+
+/// <summary>
+/// 매치 세션 저장소 Port 인터페이스
+/// Infrastructure 레이어에서 구현됩니다.
+/// </summary>
+public interface IMatchSessionRepository
+{
+    /// <summary>
+    /// 매치 세션 생성
+    /// </summary>
+    /// <param name="session">매치 세션</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    Task CreateAsync(DomainMatchSession session, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 세션 ID로 매치 세션 조회
+    /// </summary>
+    /// <param name="sessionId">세션 ID</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 세션, 없으면 null</returns>
+    Task<DomainMatchSession?> FindByIdAsync(Guid sessionId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 매치 ID로 매치 세션 조회
+    /// </summary>
+    /// <param name="matchId">매치 ID</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 세션, 없으면 null</returns>
+    Task<DomainMatchSession?> FindByMatchIdAsync(Guid matchId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// 매치 세션 업데이트
+    /// </summary>
+    /// <param name="session">매치 세션</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    Task UpdateAsync(DomainMatchSession session, CancellationToken cancellationToken = default);
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/UseCases/EndMatchUseCase.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/UseCases/EndMatchUseCase.cs
@@ -1,0 +1,55 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Application.MatchSession.Mappers;
+using FpsServer.Application.MatchSession.Ports;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession.Exceptions;
+
+namespace FpsServer.Application.MatchSession.UseCases;
+
+/// <summary>
+/// 매치 종료 유스케이스
+/// </summary>
+public class EndMatchUseCase
+{
+    private readonly IMatchSessionRepository _repository;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="repository">매치 세션 저장소</param>
+    public EndMatchUseCase(IMatchSessionRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+    
+    /// <summary>
+    /// 매치 종료
+    /// </summary>
+    /// <param name="request">매치 종료 요청</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 종료 응답</returns>
+    /// <exception cref="MatchSessionNotFoundException">매치 세션을 찾을 수 없는 경우</exception>
+    /// <exception cref="InvalidMatchSessionStateException">유효하지 않은 상태 전이인 경우</exception>
+    public async Task<EndMatchResponse> ExecuteAsync(
+        EndMatchRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. 세션 조회 (매치 ID로)
+        var session = await _repository.FindByMatchIdAsync(request.MatchId, cancellationToken);
+        if (session == null)
+            throw new MatchSessionNotFoundException(request.MatchId);
+        
+        // 2. DTO를 Domain 모델로 변환
+        var result = MatchSessionMapper.ToDomain(request);
+        
+        // 3. 게임 종료 (상태 전이: InProgress → Finished)
+        session.End(result);
+        
+        // 4. 세션 업데이트
+        await _repository.UpdateAsync(session, cancellationToken);
+        
+        // 5. 응답 반환
+        return MatchSessionMapper.ToEndResponse(session);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/MatchSession/UseCases/StartMatchUseCase.cs
+++ b/src/Services/FpsServer/FpsServer.Application/MatchSession/UseCases/StartMatchUseCase.cs
@@ -1,0 +1,66 @@
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Application.MatchSession.Mappers;
+using FpsServer.Application.MatchSession.Ports;
+using FpsServer.Domain.Matchmaking;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession.Exceptions;
+
+namespace FpsServer.Application.MatchSession.UseCases;
+
+/// <summary>
+/// 매치 시작 유스케이스
+/// </summary>
+public class StartMatchUseCase
+{
+    private readonly IMatchSessionRepository _repository;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="repository">매치 세션 저장소</param>
+    public StartMatchUseCase(IMatchSessionRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+    
+    /// <summary>
+    /// 매치 시작
+    /// </summary>
+    /// <param name="request">매치 시작 요청</param>
+    /// <param name="gameMode">게임 모드</param>
+    /// <param name="cancellationToken">취소 토큰</param>
+    /// <returns>매치 시작 응답</returns>
+    /// <exception cref="MatchSessionNotFoundException">매치 세션을 찾을 수 없는 경우</exception>
+    /// <exception cref="InvalidMatchSessionStateException">유효하지 않은 상태 전이인 경우</exception>
+    public async Task<StartMatchResponse> ExecuteAsync(
+        StartMatchRequest request,
+        MatchmakingMode gameMode,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. 기존 세션 조회 (매치 ID로)
+        var existingSession = await _repository.FindByMatchIdAsync(request.MatchId, cancellationToken);
+        
+        DomainMatchSession session;
+        if (existingSession != null)
+        {
+            // 기존 세션이 있으면 재사용
+            session = existingSession;
+        }
+        else
+        {
+            // 2. 새 세션 생성
+            session = MatchSessionMapper.ToDomain(request, gameMode);
+            await _repository.CreateAsync(session, cancellationToken);
+        }
+        
+        // 3. 게임 시작 (상태 전이: Matched → InProgress)
+        session.Start();
+        
+        // 4. 세션 업데이트
+        await _repository.UpdateAsync(session, cancellationToken);
+        
+        // 5. 응답 반환
+        return MatchSessionMapper.ToStartResponse(session);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Application/Matchmaking/Mappers/MatchmakingMapper.cs
+++ b/src/Services/FpsServer/FpsServer.Application/Matchmaking/Mappers/MatchmakingMapper.cs
@@ -1,5 +1,6 @@
 using FpsServer.Application.Matchmaking.DTOs;
 using FpsServer.Domain.Matchmaking;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 
 namespace FpsServer.Application.Matchmaking.Mappers;
 
@@ -16,7 +17,7 @@ public static class MatchmakingMapper
         return new PlayerMatchRequest(
             request.PlayerId,
             request.GameMode,
-            new MMR(request.MMR)
+            new DomainMMR(request.MMR)
         );
     }
     

--- a/src/Services/FpsServer/FpsServer.Domain/MMR/EloRatingCalculator.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MMR/EloRatingCalculator.cs
@@ -1,0 +1,56 @@
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+
+namespace FpsServer.Domain.MMR;
+
+/// <summary>
+/// Elo 레이팅 시스템 기반 MMR 계산기
+/// 
+/// Elo 레이팅 시스템은 체스 레이팅 시스템으로 널리 사용되며, 게임 매칭 시스템에서도 표준으로 사용됩니다.
+/// 
+/// 공식:
+/// - Expected Score = 1 / (1 + 10^((Opponent MMR - Player MMR) / 400))
+/// - New MMR = Old MMR + K * (Actual Score - Expected Score)
+/// 
+/// 참고 자료:
+/// - [엘로 평점 시스템 (위키백과)](https://ko.wikipedia.org/wiki/엘로_평점_시스템)
+/// - [Elo 레이팅 (나무위키)](https://namu.wiki/w/Elo%20레이팅)
+/// </summary>
+public class EloRatingCalculator : IMMRCalculator
+{
+    /// <summary>
+    /// 새로운 MMR 계산
+    /// </summary>
+    /// <param name="currentMMR">현재 MMR</param>
+    /// <param name="opponentAverageMMR">상대방 평균 MMR (팀 매칭의 경우 팀 평균)</param>
+    /// <param name="actualScore">실제 점수 (1.0: 승리, 0.5: 무승부, 0.0: 패배)</param>
+    /// <param name="kFactor">K 값 (기본값: 32, 조정 가능)</param>
+    /// <returns>계산된 새로운 MMR</returns>
+    /// <exception cref="ArgumentException">actualScore가 0.0~1.0 범위를 벗어나거나, kFactor가 0 이하인 경우</exception>
+    public DomainMMR CalculateNewMMR(
+        DomainMMR currentMMR,
+        DomainMMR opponentAverageMMR,
+        double actualScore,
+        int kFactor = 32)
+    {
+        if (actualScore < 0.0 || actualScore > 1.0)
+            throw new ArgumentException("Actual score must be between 0.0 and 1.0", nameof(actualScore));
+        
+        if (kFactor <= 0)
+            throw new ArgumentException("K factor must be greater than 0", nameof(kFactor));
+        
+        // Expected Score 계산: 1 / (1 + 10^((Opponent MMR - Player MMR) / 400))
+        var ratingDifference = opponentAverageMMR.Value - currentMMR.Value;
+        var expectedScore = 1.0 / (1.0 + Math.Pow(10, ratingDifference / 400.0));
+        
+        // New MMR 계산: Old MMR + K * (Actual Score - Expected Score)
+        var mmrChange = (int)Math.Round(kFactor * (actualScore - expectedScore));
+        var newMMRValue = currentMMR.Value + mmrChange;
+        
+        // MMR은 0 이상이어야 함
+        if (newMMRValue < 0)
+            newMMRValue = 0;
+        
+        return new DomainMMR(newMMRValue);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MMR/IMMRCalculator.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MMR/IMMRCalculator.cs
@@ -1,0 +1,26 @@
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+
+namespace FpsServer.Domain.MMR;
+
+/// <summary>
+/// MMR 계산기 인터페이스
+/// 다양한 MMR 계산 알고리즘을 지원하기 위한 인터페이스입니다.
+/// MVP에서는 EloRatingCalculator만 제공하며, 향후 다른 알고리즘(Glicko, TrueSkill 등) 추가 가능합니다.
+/// </summary>
+public interface IMMRCalculator
+{
+    /// <summary>
+    /// 새로운 MMR 계산
+    /// </summary>
+    /// <param name="currentMMR">현재 MMR</param>
+    /// <param name="opponentAverageMMR">상대방 평균 MMR (팀 매칭의 경우 팀 평균)</param>
+    /// <param name="actualScore">실제 점수 (1.0: 승리, 0.5: 무승부, 0.0: 패배)</param>
+    /// <param name="kFactor">K 값 (기본값: 32, 조정 가능)</param>
+    /// <returns>계산된 새로운 MMR</returns>
+    DomainMMR CalculateNewMMR(
+        DomainMMR currentMMR,
+        DomainMMR opponentAverageMMR,
+        double actualScore,
+        int kFactor = 32);
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MMR/PlayerMMR.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MMR/PlayerMMR.cs
@@ -1,0 +1,62 @@
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+
+namespace FpsServer.Domain.MMR;
+
+/// <summary>
+/// 플레이어 MMR 엔티티
+/// 플레이어의 현재 MMR 값을 관리합니다.
+/// </summary>
+public class PlayerMMR
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public Guid PlayerId { get; private set; }
+    
+    /// <summary>
+    /// 현재 MMR 값
+    /// </summary>
+    public DomainMMR CurrentMMR { get; private set; }
+    
+    /// <summary>
+    /// MMR 업데이트 시간
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; private set; }
+    
+    // EF Core용 private 생성자
+    private PlayerMMR()
+    {
+        CurrentMMR = new DomainMMR(1500); // 기본값
+    }
+    
+    /// <summary>
+    /// 플레이어 MMR 생성
+    /// </summary>
+    /// <param name="playerId">플레이어 ID</param>
+    /// <param name="initialMMR">초기 MMR 값 (기본값: 1500)</param>
+    /// <exception cref="ArgumentException">플레이어 ID가 비어있는 경우</exception>
+    public PlayerMMR(Guid playerId, DomainMMR? initialMMR = null)
+    {
+        if (playerId == Guid.Empty)
+            throw new ArgumentException("PlayerId cannot be empty", nameof(playerId));
+        
+        PlayerId = playerId;
+        CurrentMMR = initialMMR ?? new DomainMMR(1500); // 기본 MMR: 1500
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+    
+    /// <summary>
+    /// MMR 업데이트
+    /// </summary>
+    /// <param name="newMMR">새로운 MMR 값</param>
+    /// <exception cref="ArgumentNullException">MMR 값이 null인 경우</exception>
+    public void UpdateMMR(DomainMMR newMMR)
+    {
+        if (newMMR.Value < 0)
+            throw new ArgumentException("MMR cannot be negative", nameof(newMMR));
+        
+        CurrentMMR = newMMR;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/InvalidMatchSessionStateException.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/InvalidMatchSessionStateException.cs
@@ -1,0 +1,22 @@
+using FpsServer.Domain.MatchSession;
+
+namespace FpsServer.Domain.MatchSession.Exceptions;
+
+/// <summary>
+/// 매치 세션 상태 전이가 유효하지 않은 경우 발생하는 예외
+/// </summary>
+public class InvalidMatchSessionStateException : MatchSessionException
+{
+    public MatchStatus CurrentStatus { get; }
+    public MatchStatus AttemptedStatus { get; }
+    
+    public InvalidMatchSessionStateException(
+        MatchStatus currentStatus, 
+        MatchStatus attemptedStatus)
+        : base($"Invalid state transition from {currentStatus} to {attemptedStatus}")
+    {
+        CurrentStatus = currentStatus;
+        AttemptedStatus = attemptedStatus;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/MatchSessionException.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/MatchSessionException.cs
@@ -1,0 +1,13 @@
+namespace FpsServer.Domain.MatchSession.Exceptions;
+
+/// <summary>
+/// 매치 세션 관련 예외의 베이스 클래스
+/// </summary>
+public class MatchSessionException : Exception
+{
+    public MatchSessionException(string message) : base(message) { }
+    
+    public MatchSessionException(string message, Exception innerException) 
+        : base(message, innerException) { }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/MatchSessionNotFoundException.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/Exceptions/MatchSessionNotFoundException.cs
@@ -1,0 +1,16 @@
+namespace FpsServer.Domain.MatchSession.Exceptions;
+
+/// <summary>
+/// 매치 세션을 찾을 수 없는 경우 발생하는 예외
+/// </summary>
+public class MatchSessionNotFoundException : MatchSessionException
+{
+    public Guid MatchId { get; }
+    
+    public MatchSessionNotFoundException(Guid matchId)
+        : base($"Match session not found for MatchId: {matchId}")
+    {
+        MatchId = matchId;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchResult.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchResult.cs
@@ -1,0 +1,68 @@
+namespace FpsServer.Domain.MatchSession;
+
+/// <summary>
+/// 매치 결과 엔티티
+/// </summary>
+public class MatchResult
+{
+    /// <summary>
+    /// 매치 결과 ID
+    /// </summary>
+    public Guid ResultId { get; private set; }
+    
+    /// <summary>
+    /// 매치 ID
+    /// </summary>
+    public Guid MatchId { get; private set; }
+    
+    /// <summary>
+    /// 플레이어 결과 목록
+    /// </summary>
+    public IReadOnlyList<PlayerResult> PlayerResults { get; private set; }
+    
+    /// <summary>
+    /// 승리 팀/플레이어 ID (선택적)
+    /// </summary>
+    public Guid? WinnerId { get; private set; }
+    
+    /// <summary>
+    /// 매치 종료 시간
+    /// </summary>
+    public DateTimeOffset EndedAt { get; private set; }
+    
+    // EF Core용 private 생성자
+    private MatchResult()
+    {
+        PlayerResults = new List<PlayerResult>();
+    }
+    
+    /// <summary>
+    /// 매치 결과 생성
+    /// </summary>
+    /// <param name="matchId">매치 ID</param>
+    /// <param name="playerResults">플레이어 결과 목록</param>
+    /// <param name="winnerId">승리 팀/플레이어 ID (선택적)</param>
+    /// <exception cref="ArgumentNullException">플레이어 결과 목록이 null인 경우</exception>
+    /// <exception cref="ArgumentException">플레이어 결과 목록이 비어있는 경우</exception>
+    public MatchResult(
+        Guid matchId, 
+        IReadOnlyList<PlayerResult> playerResults, 
+        Guid? winnerId = null)
+    {
+        if (matchId == Guid.Empty)
+            throw new ArgumentException("MatchId cannot be empty", nameof(matchId));
+        
+        if (playerResults == null)
+            throw new ArgumentNullException(nameof(playerResults));
+        
+        if (playerResults.Count == 0)
+            throw new ArgumentException("PlayerResults cannot be empty", nameof(playerResults));
+        
+        ResultId = Guid.NewGuid();
+        MatchId = matchId;
+        PlayerResults = playerResults;
+        WinnerId = winnerId;
+        EndedAt = DateTimeOffset.UtcNow;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchSession.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchSession.cs
@@ -1,0 +1,133 @@
+using FpsServer.Domain.Matchmaking;
+using FpsServer.Domain.MatchSession.Exceptions;
+
+namespace FpsServer.Domain.MatchSession;
+
+/// <summary>
+/// 매치 세션 Aggregate Root
+/// 게임 세션의 라이프사이클을 관리하며, 상태 전이 규칙을 보장합니다.
+/// </summary>
+public class MatchSession
+{
+    private MatchResult? _result;
+    
+    /// <summary>
+    /// 세션 ID
+    /// </summary>
+    public Guid SessionId { get; private set; }
+    
+    /// <summary>
+    /// 매치 ID (매칭 시스템에서 생성된 ID)
+    /// </summary>
+    public Guid MatchId { get; private set; }
+    
+    /// <summary>
+    /// 세션 상태
+    /// </summary>
+    public MatchStatus Status { get; private set; }
+    
+    /// <summary>
+    /// 게임 시작 시간
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; private set; }
+    
+    /// <summary>
+    /// 게임 종료 시간
+    /// </summary>
+    public DateTimeOffset? EndedAt { get; private set; }
+    
+    /// <summary>
+    /// 플레이어 ID 목록
+    /// </summary>
+    public IReadOnlyList<Guid> PlayerIds { get; private set; }
+    
+    /// <summary>
+    /// 게임 모드
+    /// </summary>
+    public MatchmakingMode GameMode { get; private set; }
+    
+    /// <summary>
+    /// 매치 결과 (게임 종료 후 설정)
+    /// </summary>
+    public MatchResult? Result => _result;
+    
+    // EF Core용 private 생성자
+    private MatchSession()
+    {
+        PlayerIds = new List<Guid>();
+    }
+    
+    /// <summary>
+    /// 매치 세션 생성
+    /// </summary>
+    /// <param name="matchId">매치 ID</param>
+    /// <param name="playerIds">플레이어 ID 목록</param>
+    /// <param name="gameMode">게임 모드</param>
+    /// <exception cref="ArgumentException">매치 ID가 비어있거나 플레이어 목록이 비어있는 경우</exception>
+    public MatchSession(Guid matchId, IReadOnlyList<Guid> playerIds, MatchmakingMode gameMode)
+    {
+        if (matchId == Guid.Empty)
+            throw new ArgumentException("MatchId cannot be empty", nameof(matchId));
+        
+        if (playerIds == null || playerIds.Count == 0)
+            throw new ArgumentException("PlayerIds cannot be null or empty", nameof(playerIds));
+        
+        SessionId = Guid.NewGuid();
+        MatchId = matchId;
+        PlayerIds = playerIds;
+        GameMode = gameMode;
+        Status = MatchStatus.Matched;
+    }
+    
+    /// <summary>
+    /// 게임 시작
+    /// 상태 전이: Matched → InProgress
+    /// </summary>
+    /// <exception cref="InvalidMatchSessionStateException">현재 상태에서 시작할 수 없는 경우</exception>
+    public void Start()
+    {
+        if (Status != MatchStatus.Matched)
+            throw new InvalidMatchSessionStateException(Status, MatchStatus.InProgress);
+        
+        Status = MatchStatus.InProgress;
+        StartedAt = DateTimeOffset.UtcNow;
+    }
+    
+    /// <summary>
+    /// 게임 종료
+    /// 상태 전이: InProgress → Finished
+    /// </summary>
+    /// <param name="result">매치 결과</param>
+    /// <exception cref="ArgumentNullException">결과가 null인 경우</exception>
+    /// <exception cref="InvalidMatchSessionStateException">현재 상태에서 종료할 수 없는 경우</exception>
+    public void End(MatchResult result)
+    {
+        if (result == null)
+            throw new ArgumentNullException(nameof(result));
+        
+        if (Status != MatchStatus.InProgress)
+            throw new InvalidMatchSessionStateException(Status, MatchStatus.Finished);
+        
+        if (result.MatchId != MatchId)
+            throw new ArgumentException($"MatchId mismatch. Session MatchId: {MatchId}, Result MatchId: {result.MatchId}", nameof(result));
+        
+        Status = MatchStatus.Finished;
+        EndedAt = DateTimeOffset.UtcNow;
+        _result = result;
+    }
+    
+    /// <summary>
+    /// 게임 취소
+    /// 상태 전이: Matched 또는 InProgress → Cancelled
+    /// </summary>
+    /// <exception cref="InvalidMatchSessionStateException">현재 상태에서 취소할 수 없는 경우</exception>
+    public void Cancel()
+    {
+        if (Status != MatchStatus.Matched && Status != MatchStatus.InProgress)
+            throw new InvalidMatchSessionStateException(Status, MatchStatus.Cancelled);
+        
+        Status = MatchStatus.Cancelled;
+        EndedAt = DateTimeOffset.UtcNow;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchStatus.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/MatchStatus.cs
@@ -1,0 +1,33 @@
+namespace FpsServer.Domain.MatchSession;
+
+/// <summary>
+/// 매치 세션 상태
+/// </summary>
+public enum MatchStatus
+{
+    /// <summary>
+    /// 매칭 완료 (게임 시작 전)
+    /// </summary>
+    Matched = 1,
+    
+    /// <summary>
+    /// 게임 시작 중 (초기화 단계)
+    /// </summary>
+    Starting = 2,
+    
+    /// <summary>
+    /// 게임 진행 중
+    /// </summary>
+    InProgress = 3,
+    
+    /// <summary>
+    /// 게임 종료
+    /// </summary>
+    Finished = 4,
+    
+    /// <summary>
+    /// 게임 취소됨
+    /// </summary>
+    Cancelled = 5
+}
+

--- a/src/Services/FpsServer/FpsServer.Domain/MatchSession/PlayerResult.cs
+++ b/src/Services/FpsServer/FpsServer.Domain/MatchSession/PlayerResult.cs
@@ -1,0 +1,39 @@
+namespace FpsServer.Domain.MatchSession;
+
+/// <summary>
+/// 플레이어 매치 결과 값 객체
+/// </summary>
+public record PlayerResult
+{
+    /// <summary>
+    /// 플레이어 ID
+    /// </summary>
+    public Guid PlayerId { get; init; }
+    
+    /// <summary>
+    /// 승리 여부
+    /// </summary>
+    public bool IsWinner { get; init; }
+    
+    /// <summary>
+    /// 점수 (게임별 통계, 선택적)
+    /// </summary>
+    public int? Score { get; init; }
+    
+    /// <summary>
+    /// 플레이어 결과 생성
+    /// </summary>
+    /// <param name="playerId">플레이어 ID</param>
+    /// <param name="isWinner">승리 여부</param>
+    /// <param name="score">점수 (선택적)</param>
+    public PlayerResult(Guid playerId, bool isWinner, int? score = null)
+    {
+        if (playerId == Guid.Empty)
+            throw new ArgumentException("PlayerId cannot be empty", nameof(playerId));
+        
+        PlayerId = playerId;
+        IsWinner = isWinner;
+        Score = score;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/FpsServer.Infrastructure.csproj
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/FpsServer.Infrastructure.csproj
@@ -8,6 +8,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MMR/EfPlayerMMRRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MMR/EfPlayerMMRRepository.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.MMR;
+using FpsServer.Infrastructure.Persistence;
+
+namespace FpsServer.Infrastructure.MMR;
+
+/// <summary>
+/// EF Core 기반 플레이어 MMR 저장소
+/// </summary>
+public class EfPlayerMMRRepository : IPlayerMMRRepository
+{
+    private readonly FpsDbContext _context;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="context">DbContext</param>
+    public EfPlayerMMRRepository(FpsDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+    
+    /// <summary>
+    /// 플레이어 ID로 MMR 조회
+    /// </summary>
+    public async Task<PlayerMMR?> FindByPlayerIdAsync(Guid playerId, CancellationToken cancellationToken = default)
+    {
+        return await _context.PlayerMMRs
+            .FirstOrDefaultAsync(p => p.PlayerId == playerId, cancellationToken);
+    }
+    
+    /// <summary>
+    /// 여러 플레이어 ID로 MMR 목록 조회
+    /// </summary>
+    public async Task<IReadOnlyList<PlayerMMR>> FindMultipleByPlayerIdsAsync(
+        IReadOnlyList<Guid> playerIds,
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.PlayerMMRs
+            .Where(p => playerIds.Contains(p.PlayerId))
+            .ToListAsync(cancellationToken);
+    }
+    
+    /// <summary>
+    /// 플레이어 MMR 생성 또는 업데이트
+    /// </summary>
+    public async Task SaveAsync(PlayerMMR playerMMR, CancellationToken cancellationToken = default)
+    {
+        var existing = await _context.PlayerMMRs
+            .FirstOrDefaultAsync(p => p.PlayerId == playerMMR.PlayerId, cancellationToken);
+        
+        if (existing == null)
+        {
+            await _context.PlayerMMRs.AddAsync(playerMMR, cancellationToken);
+        }
+        else
+        {
+            _context.PlayerMMRs.Update(playerMMR);
+        }
+        
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+    
+    /// <summary>
+    /// 여러 플레이어 MMR 일괄 저장
+    /// </summary>
+    public async Task SaveMultipleAsync(
+        IReadOnlyList<PlayerMMR> playerMMRs,
+        CancellationToken cancellationToken = default)
+    {
+        var playerIds = playerMMRs.Select(p => p.PlayerId).ToList();
+        var existing = await _context.PlayerMMRs
+            .AsNoTracking()
+            .Where(p => playerIds.Contains(p.PlayerId))
+            .ToListAsync(cancellationToken);
+        
+        var existingIds = existing.Select(p => p.PlayerId).ToHashSet();
+        
+        foreach (var playerMMR in playerMMRs)
+        {
+            if (existingIds.Contains(playerMMR.PlayerId))
+            {
+                var tracked = await _context.PlayerMMRs
+                    .FirstOrDefaultAsync(p => p.PlayerId == playerMMR.PlayerId, cancellationToken);
+                if (tracked != null)
+                {
+                    _context.Entry(tracked).CurrentValues.SetValues(playerMMR);
+                }
+            }
+            else
+            {
+                await _context.PlayerMMRs.AddAsync(playerMMR, cancellationToken);
+            }
+        }
+        
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MMR/InMemoryPlayerMMRRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MMR/InMemoryPlayerMMRRepository.cs
@@ -1,0 +1,62 @@
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.MMR;
+using System.Collections.Concurrent;
+
+namespace FpsServer.Infrastructure.MMR;
+
+/// <summary>
+/// 메모리 기반 플레이어 MMR 저장소 (MVP)
+/// 향후 EF Core 기반 구현으로 교체 예정 (#26)
+/// </summary>
+public class InMemoryPlayerMMRRepository : IPlayerMMRRepository
+{
+    private readonly ConcurrentDictionary<Guid, PlayerMMR> _playerMMRs = new();
+    
+    /// <summary>
+    /// 플레이어 ID로 MMR 조회
+    /// </summary>
+    public Task<PlayerMMR?> FindByPlayerIdAsync(Guid playerId, CancellationToken cancellationToken = default)
+    {
+        _playerMMRs.TryGetValue(playerId, out var playerMMR);
+        return Task.FromResult<PlayerMMR?>(playerMMR);
+    }
+    
+    /// <summary>
+    /// 여러 플레이어 ID로 MMR 목록 조회
+    /// </summary>
+    public Task<IReadOnlyList<PlayerMMR>> FindMultipleByPlayerIdsAsync(
+        IReadOnlyList<Guid> playerIds,
+        CancellationToken cancellationToken = default)
+    {
+        var results = playerIds
+            .Where(id => _playerMMRs.ContainsKey(id))
+            .Select(id => _playerMMRs[id])
+            .ToList();
+        
+        return Task.FromResult<IReadOnlyList<PlayerMMR>>(results);
+    }
+    
+    /// <summary>
+    /// 플레이어 MMR 생성 또는 업데이트
+    /// </summary>
+    public Task SaveAsync(PlayerMMR playerMMR, CancellationToken cancellationToken = default)
+    {
+        _playerMMRs[playerMMR.PlayerId] = playerMMR;
+        return Task.CompletedTask;
+    }
+    
+    /// <summary>
+    /// 여러 플레이어 MMR 일괄 저장
+    /// </summary>
+    public Task SaveMultipleAsync(
+        IReadOnlyList<PlayerMMR> playerMMRs,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var playerMMR in playerMMRs)
+        {
+            _playerMMRs[playerMMR.PlayerId] = playerMMR;
+        }
+        return Task.CompletedTask;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MMR/ServiceCollectionExtensions.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MMR/ServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Domain.MMR;
+using FpsServer.Infrastructure.Persistence;
+
+namespace FpsServer.Infrastructure.MMR;
+
+/// <summary>
+/// MMR Infrastructure 레이어 DI 확장 메서드
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// MMR Infrastructure 서비스 등록
+    /// </summary>
+    /// <param name="services">서비스 컬렉션</param>
+    /// <param name="connectionString">데이터베이스 연결 문자열 (선택적, 없으면 In-Memory 사용)</param>
+    /// <returns>서비스 컬렉션 (체이닝 지원)</returns>
+    public static IServiceCollection AddMMRInfrastructure(
+        this IServiceCollection services,
+        string? connectionString = null)
+    {
+        // Repository 구현 등록
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            // EF Core 기반 Repository 사용
+            // DbContext는 AddMatchSessionInfrastructure에서 이미 등록되었을 수 있으므로 확인 필요
+            services.AddScoped<IPlayerMMRRepository, EfPlayerMMRRepository>();
+        }
+        else
+        {
+            // In-Memory Repository 사용 (MVP)
+            services.AddSingleton<IPlayerMMRRepository, InMemoryPlayerMMRRepository>();
+        }
+        
+        // MMR Calculator 등록 (Domain Service)
+        services.AddSingleton<IMMRCalculator, EloRatingCalculator>();
+        
+        return services;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/EfMatchSessionRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/EfMatchSessionRepository.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using FpsServer.Application.MatchSession.Ports;
+using FpsServer.Infrastructure.Persistence;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+
+namespace FpsServer.Infrastructure.MatchSession;
+
+/// <summary>
+/// EF Core 기반 매치 세션 저장소
+/// </summary>
+public class EfMatchSessionRepository : IMatchSessionRepository
+{
+    private readonly FpsDbContext _context;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="context">DbContext</param>
+    public EfMatchSessionRepository(FpsDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+    
+    /// <summary>
+    /// 매치 세션 생성
+    /// </summary>
+    public async Task CreateAsync(DomainMatchSession session, CancellationToken cancellationToken = default)
+    {
+        await _context.MatchSessions.AddAsync(session, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+    
+    /// <summary>
+    /// 세션 ID로 매치 세션 조회
+    /// </summary>
+    public async Task<DomainMatchSession?> FindByIdAsync(Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        return await _context.MatchSessions
+            .FirstOrDefaultAsync(s => s.SessionId == sessionId, cancellationToken);
+    }
+    
+    /// <summary>
+    /// 매치 ID로 매치 세션 조회
+    /// </summary>
+    public async Task<DomainMatchSession?> FindByMatchIdAsync(Guid matchId, CancellationToken cancellationToken = default)
+    {
+        return await _context.MatchSessions
+            .FirstOrDefaultAsync(s => s.MatchId == matchId, cancellationToken);
+    }
+    
+    /// <summary>
+    /// 매치 세션 업데이트
+    /// </summary>
+    public async Task UpdateAsync(DomainMatchSession session, CancellationToken cancellationToken = default)
+    {
+        _context.MatchSessions.Update(session);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/InMemoryMatchSessionRepository.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/InMemoryMatchSessionRepository.cs
@@ -1,0 +1,57 @@
+using FpsServer.Application.MatchSession.Ports;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using System.Collections.Concurrent;
+
+namespace FpsServer.Infrastructure.MatchSession;
+
+/// <summary>
+/// 메모리 기반 매치 세션 저장소 (MVP)
+/// 향후 EF Core 기반 구현으로 교체 예정 (#26)
+/// </summary>
+public class InMemoryMatchSessionRepository : IMatchSessionRepository
+{
+    private readonly ConcurrentDictionary<Guid, DomainMatchSession> _sessions = new();
+    private readonly ConcurrentDictionary<Guid, Guid> _matchIdToSessionId = new(); // MatchId -> SessionId 매핑
+    
+    /// <summary>
+    /// 매치 세션 생성
+    /// </summary>
+    public Task CreateAsync(DomainMatchSession session, CancellationToken cancellationToken = default)
+    {
+        _sessions[session.SessionId] = session;
+        _matchIdToSessionId[session.MatchId] = session.SessionId;
+        return Task.CompletedTask;
+    }
+    
+    /// <summary>
+    /// 세션 ID로 매치 세션 조회
+    /// </summary>
+    public Task<DomainMatchSession?> FindByIdAsync(Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        _sessions.TryGetValue(sessionId, out var session);
+        return Task.FromResult<DomainMatchSession?>(session);
+    }
+    
+    /// <summary>
+    /// 매치 ID로 매치 세션 조회
+    /// </summary>
+    public Task<DomainMatchSession?> FindByMatchIdAsync(Guid matchId, CancellationToken cancellationToken = default)
+    {
+        if (_matchIdToSessionId.TryGetValue(matchId, out var sessionId))
+        {
+            _sessions.TryGetValue(sessionId, out var session);
+            return Task.FromResult<DomainMatchSession?>(session);
+        }
+        return Task.FromResult<DomainMatchSession?>(null);
+    }
+    
+    /// <summary>
+    /// 매치 세션 업데이트
+    /// </summary>
+    public Task UpdateAsync(DomainMatchSession session, CancellationToken cancellationToken = default)
+    {
+        _sessions[session.SessionId] = session;
+        return Task.CompletedTask;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/ServiceCollectionExtensions.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/MatchSession/ServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using FpsServer.Application.MatchSession.Ports;
+using FpsServer.Infrastructure.Persistence;
+
+namespace FpsServer.Infrastructure.MatchSession;
+
+/// <summary>
+/// 매치 세션 Infrastructure 레이어 DI 확장 메서드
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// 매치 세션 Infrastructure 서비스 등록
+    /// </summary>
+    /// <param name="services">서비스 컬렉션</param>
+    /// <param name="connectionString">데이터베이스 연결 문자열 (선택적, 없으면 In-Memory 사용)</param>
+    /// <returns>서비스 컬렉션 (체이닝 지원)</returns>
+    public static IServiceCollection AddMatchSessionInfrastructure(
+        this IServiceCollection services,
+        string? connectionString = null)
+    {
+        // DbContext 등록
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            // EF Core 기반 Repository 사용
+            services.AddDbContext<FpsDbContext>(options =>
+                options.UseSqlServer(connectionString));
+            services.AddScoped<IMatchSessionRepository, EfMatchSessionRepository>();
+        }
+        else
+        {
+            // In-Memory Repository 사용 (MVP)
+            services.AddSingleton<IMatchSessionRepository, InMemoryMatchSessionRepository>();
+        }
+        
+        return services;
+    }
+}
+

--- a/src/Services/FpsServer/FpsServer.Infrastructure/Persistence/FpsDbContext.cs
+++ b/src/Services/FpsServer/FpsServer.Infrastructure/Persistence/FpsDbContext.cs
@@ -1,0 +1,151 @@
+using Microsoft.EntityFrameworkCore;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using DomainMatchResult = FpsServer.Domain.MatchSession.MatchResult;
+using DomainPlayerResult = FpsServer.Domain.MatchSession.PlayerResult;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+using FpsServer.Domain.MMR;
+using FpsServer.Domain.Matchmaking;
+
+namespace FpsServer.Infrastructure.Persistence;
+
+/// <summary>
+/// FPS 서버 DbContext
+/// </summary>
+public class FpsDbContext : DbContext
+{
+    /// <summary>
+    /// 매치 세션 DbSet
+    /// </summary>
+    public DbSet<DomainMatchSession> MatchSessions { get; set; } = null!;
+    
+    /// <summary>
+    /// 매치 결과 DbSet
+    /// </summary>
+    public DbSet<DomainMatchResult> MatchResults { get; set; } = null!;
+    
+    /// <summary>
+    /// 플레이어 MMR DbSet
+    /// </summary>
+    public DbSet<PlayerMMR> PlayerMMRs { get; set; } = null!;
+    
+    /// <summary>
+    /// 생성자
+    /// </summary>
+    /// <param name="options">DbContext 옵션</param>
+    public FpsDbContext(DbContextOptions<FpsDbContext> options)
+        : base(options)
+    {
+    }
+    
+    /// <summary>
+    /// 모델 구성 (Fluent API)
+    /// </summary>
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        
+        // MatchSession 엔티티 매핑
+        modelBuilder.Entity<DomainMatchSession>(entity =>
+        {
+            entity.ToTable("MatchSessions");
+            entity.HasKey(e => e.SessionId);
+            
+            entity.Property(e => e.SessionId)
+                .HasColumnName("SessionId");
+            
+            entity.Property(e => e.MatchId)
+                .HasColumnName("MatchId")
+                .IsRequired();
+            
+            entity.Property(e => e.Status)
+                .HasColumnName("Status")
+                .HasConversion<int>()
+                .IsRequired();
+            
+            entity.Property(e => e.StartedAt)
+                .HasColumnName("StartedAt");
+            
+            entity.Property(e => e.EndedAt)
+                .HasColumnName("EndedAt");
+            
+            entity.Property(e => e.GameMode)
+                .HasColumnName("GameMode")
+                .HasConversion<int>()
+                .IsRequired();
+            
+            // PlayerIds를 JSON으로 저장 (EF Core 8 Complex Type 대신)
+            entity.Property(e => e.PlayerIds)
+                .HasColumnName("PlayerIds")
+                .HasConversion(
+                    v => string.Join(",", v),
+                    v => v.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(Guid.Parse)
+                        .ToList())
+                .IsRequired();
+            
+            // MatchResult와의 관계는 MatchId를 통해 연결 (별도 엔티티)
+            // MatchSession의 Result 속성은 private 필드이므로 EF Core가 자동으로 매핑하지 않음
+            // 필요 시 MatchId로 조회하여 사용
+            
+            // MatchId에 인덱스 추가
+            entity.HasIndex(e => e.MatchId)
+                .IsUnique();
+        });
+        
+        // MatchResult 엔티티 매핑
+        modelBuilder.Entity<DomainMatchResult>(entity =>
+        {
+            entity.ToTable("MatchResults");
+            entity.HasKey(e => e.ResultId);
+            
+            entity.Property(e => e.ResultId)
+                .HasColumnName("ResultId");
+            
+            entity.Property(e => e.MatchId)
+                .HasColumnName("MatchId")
+                .IsRequired();
+            
+            entity.Property(e => e.WinnerId)
+                .HasColumnName("WinnerId");
+            
+            entity.Property(e => e.EndedAt)
+                .HasColumnName("EndedAt")
+                .IsRequired();
+            
+            // PlayerResults를 JSON으로 저장
+            entity.Property(e => e.PlayerResults)
+                .HasColumnName("PlayerResults")
+                .HasConversion(
+                    v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
+                    v => System.Text.Json.JsonSerializer.Deserialize<IReadOnlyList<DomainPlayerResult>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new List<DomainPlayerResult>())
+                .IsRequired();
+            
+            // MatchId에 인덱스 추가
+            entity.HasIndex(e => e.MatchId)
+                .IsUnique();
+        });
+        
+        // PlayerMMR 엔티티 매핑
+        modelBuilder.Entity<PlayerMMR>(entity =>
+        {
+            entity.ToTable("PlayerMMRs");
+            entity.HasKey(e => e.PlayerId);
+            
+            entity.Property(e => e.PlayerId)
+                .HasColumnName("PlayerId");
+            
+            // MMR을 Value Conversion으로 매핑
+            entity.Property(e => e.CurrentMMR)
+                .HasColumnName("MMR")
+                .HasConversion(
+                    v => v.Value,
+                    v => new DomainMMR(v))
+                .IsRequired();
+            
+            entity.Property(e => e.UpdatedAt)
+                .HasColumnName("UpdatedAt")
+                .IsRequired();
+        });
+    }
+}
+

--- a/tests/Unit/FpsServer.Application.Tests/MMR/UpdatePlayerMMRUseCaseTests.cs
+++ b/tests/Unit/FpsServer.Application.Tests/MMR/UpdatePlayerMMRUseCaseTests.cs
@@ -1,0 +1,232 @@
+using FluentAssertions;
+using FpsServer.Application.MMR.DTOs;
+using FpsServer.Application.MMR.Ports;
+using FpsServer.Application.MMR.UseCases;
+using FpsServer.Domain.MMR;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+using Moq;
+using Xunit;
+
+namespace FpsServer.Application.Tests.MMR;
+
+[Trait("Feature", "MMR 업데이트")]
+public class UpdatePlayerMMRUseCaseTests
+{
+    private readonly Mock<IPlayerMMRRepository> _repositoryMock;
+    private readonly Mock<IMMRCalculator> _calculatorMock;
+    private readonly UpdatePlayerMMRUseCase _useCase;
+
+    public UpdatePlayerMMRUseCaseTests()
+    {
+        _repositoryMock = new Mock<IPlayerMMRRepository>();
+        _calculatorMock = new Mock<IMMRCalculator>();
+        _useCase = new UpdatePlayerMMRUseCase(_repositoryMock.Object, _calculatorMock.Object);
+    }
+
+    [Fact]
+    [Trait("Category", "MMR 업데이트 유스케이스")]
+    public async Task 기존_플레이어_MMR이_있으면_업데이트해야_한다()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var matchId = Guid.NewGuid();
+        var oldMMR = new DomainMMR(1500);
+        var newMMR = new DomainMMR(1516);
+        
+        var existingPlayerMMR = new PlayerMMR(playerId, oldMMR);
+        
+        var request = new UpdateMMRRequest
+        {
+            PlayerId = playerId,
+            MatchId = matchId,
+            IsWinner = true,
+            OpponentAverageMMR = 1500,
+            KFactor = 32
+        };
+
+        _repositoryMock
+            .Setup(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingPlayerMMR);
+        
+        _calculatorMock
+            .Setup(c => c.CalculateNewMMR(
+                It.IsAny<DomainMMR>(),
+                It.IsAny<DomainMMR>(),
+                It.IsAny<double>(),
+                It.IsAny<int>()))
+            .Returns(newMMR);
+        
+        _repositoryMock
+            .Setup(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _useCase.ExecuteAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.PlayerId.Should().Be(playerId);
+        result.OldMMR.Should().Be(1500);
+        result.NewMMR.Should().Be(1516);
+
+        _repositoryMock.Verify(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()), Times.Once);
+        _calculatorMock.Verify(c => c.CalculateNewMMR(
+            oldMMR,
+            It.Is<DomainMMR>(m => m.Value == 1500),
+            1.0,
+            32), Times.Once);
+        _repositoryMock.Verify(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "MMR 업데이트 유스케이스")]
+    public async Task 플레이어_MMR이_없으면_초기_MMR로_생성해야_한다()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var matchId = Guid.NewGuid();
+        var newMMR = new DomainMMR(1516);
+        
+        var request = new UpdateMMRRequest
+        {
+            PlayerId = playerId,
+            MatchId = matchId,
+            IsWinner = true,
+            OpponentAverageMMR = 1500,
+            KFactor = 32
+        };
+
+        _repositoryMock
+            .Setup(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlayerMMR?)null);
+        
+        _calculatorMock
+            .Setup(c => c.CalculateNewMMR(
+                It.Is<DomainMMR>(m => m.Value == 1500), // 초기 MMR: 1500
+                It.IsAny<DomainMMR>(),
+                It.IsAny<double>(),
+                It.IsAny<int>()))
+            .Returns(newMMR);
+        
+        _repositoryMock
+            .Setup(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _useCase.ExecuteAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.PlayerId.Should().Be(playerId);
+        result.OldMMR.Should().Be(1500); // 초기 MMR
+        result.NewMMR.Should().Be(1516);
+
+        _repositoryMock.Verify(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()), Times.Once);
+        _calculatorMock.Verify(c => c.CalculateNewMMR(
+            It.Is<DomainMMR>(m => m.Value == 1500), // 초기 MMR
+            It.Is<DomainMMR>(m => m.Value == 1500),
+            1.0,
+            32), Times.Once);
+        _repositoryMock.Verify(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "MMR 업데이트 유스케이스")]
+    public async Task 패배_시_실제_점수가_0_0으로_전달되어야_한다()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var matchId = Guid.NewGuid();
+        var oldMMR = new DomainMMR(1500);
+        var newMMR = new DomainMMR(1484);
+        
+        var existingPlayerMMR = new PlayerMMR(playerId, oldMMR);
+        
+        var request = new UpdateMMRRequest
+        {
+            PlayerId = playerId,
+            MatchId = matchId,
+            IsWinner = false, // 패배
+            OpponentAverageMMR = 1500,
+            KFactor = 32
+        };
+
+        _repositoryMock
+            .Setup(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingPlayerMMR);
+        
+        _calculatorMock
+            .Setup(c => c.CalculateNewMMR(
+                It.IsAny<DomainMMR>(),
+                It.IsAny<DomainMMR>(),
+                It.IsAny<double>(),
+                It.IsAny<int>()))
+            .Returns(newMMR);
+        
+        _repositoryMock
+            .Setup(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _useCase.ExecuteAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.NewMMR.Should().BeLessThan(result.OldMMR);
+
+        _calculatorMock.Verify(c => c.CalculateNewMMR(
+            It.IsAny<DomainMMR>(),
+            It.IsAny<DomainMMR>(),
+            0.0, // 패배 시 실제 점수: 0.0
+            It.IsAny<int>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "MMR 업데이트 유스케이스")]
+    public async Task 커스텀_K_값이_전달되어야_한다()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var matchId = Guid.NewGuid();
+        var oldMMR = new DomainMMR(1500);
+        var newMMR = new DomainMMR(1520);
+        
+        var existingPlayerMMR = new PlayerMMR(playerId, oldMMR);
+        
+        var request = new UpdateMMRRequest
+        {
+            PlayerId = playerId,
+            MatchId = matchId,
+            IsWinner = true,
+            OpponentAverageMMR = 1500,
+            KFactor = 64 // 커스텀 K 값
+        };
+
+        _repositoryMock
+            .Setup(r => r.FindByPlayerIdAsync(playerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingPlayerMMR);
+        
+        _calculatorMock
+            .Setup(c => c.CalculateNewMMR(
+                It.IsAny<DomainMMR>(),
+                It.IsAny<DomainMMR>(),
+                It.IsAny<double>(),
+                It.IsAny<int>()))
+            .Returns(newMMR);
+        
+        _repositoryMock
+            .Setup(r => r.SaveAsync(It.IsAny<PlayerMMR>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _useCase.ExecuteAsync(request);
+
+        // Assert
+        _calculatorMock.Verify(c => c.CalculateNewMMR(
+            It.IsAny<DomainMMR>(),
+            It.IsAny<DomainMMR>(),
+            It.IsAny<double>(),
+            64), Times.Once); // 커스텀 K 값 전달 확인
+    }
+}
+

--- a/tests/Unit/FpsServer.Application.Tests/MatchSession/EndMatchUseCaseTests.cs
+++ b/tests/Unit/FpsServer.Application.Tests/MatchSession/EndMatchUseCaseTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Application.MatchSession.Ports;
+using FpsServer.Application.MatchSession.UseCases;
+using FpsServer.Domain.Matchmaking;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession;
+using FpsServer.Domain.MatchSession.Exceptions;
+using Moq;
+using Xunit;
+
+namespace FpsServer.Application.Tests.MatchSession;
+
+[Trait("Feature", "매치 세션")]
+public class EndMatchUseCaseTests
+{
+    private readonly Mock<IMatchSessionRepository> _repositoryMock;
+    private readonly EndMatchUseCase _useCase;
+    
+    public EndMatchUseCaseTests()
+    {
+        _repositoryMock = new Mock<IMatchSessionRepository>();
+        _useCase = new EndMatchUseCase(_repositoryMock.Object);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 종료 유스케이스")]
+    public async Task 유효한_요청이면_매치를_종료해야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var player1Id = Guid.NewGuid();
+        var player2Id = Guid.NewGuid();
+        
+        var session = new DomainMatchSession(matchId, new List<Guid> { player1Id, player2Id }, MatchmakingMode.Solo);
+        session.Start(); // InProgress 상태로 전이
+        
+        var request = new EndMatchRequest
+        {
+            MatchId = matchId,
+            Results = new List<PlayerResultDto>
+            {
+                new PlayerResultDto { PlayerId = player1Id, IsWinner = true, Score = 100 },
+                new PlayerResultDto { PlayerId = player2Id, IsWinner = false, Score = 50 }
+            },
+            WinnerId = player1Id
+        };
+        
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _useCase.ExecuteAsync(request);
+        
+        // Assert
+        result.Should().NotBeNull();
+        result.SessionId.Should().Be(session.SessionId);
+        result.FinalStatus.Should().Be(MatchStatus.Finished);
+        session.Result.Should().NotBeNull();
+        session.Result!.MatchId.Should().Be(matchId);
+        
+        _repositoryMock.Verify(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 종료 유스케이스")]
+    public async Task 세션을_찾을_수_없으면_MatchSessionNotFoundException을_발생시켜야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var request = new EndMatchRequest
+        {
+            MatchId = matchId,
+            Results = new List<PlayerResultDto>
+            {
+                new PlayerResultDto { PlayerId = Guid.NewGuid(), IsWinner = true }
+            }
+        };
+        
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DomainMatchSession?)null);
+        
+        // Act
+        var act = async () => await _useCase.ExecuteAsync(request);
+        
+        // Assert
+        var exception = await act.Should().ThrowAsync<MatchSessionNotFoundException>();
+        exception.Which.MatchId.Should().Be(matchId);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 종료 유스케이스")]
+    public async Task 세션이_InProgress_상태가_아니면_InvalidMatchSessionStateException을_발생시켜야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var session = new DomainMatchSession(matchId, new List<Guid> { Guid.NewGuid() }, MatchmakingMode.Solo);
+        // Matched 상태 (아직 시작하지 않음)
+        
+        var request = new EndMatchRequest
+        {
+            MatchId = matchId,
+            Results = new List<PlayerResultDto>
+            {
+                new PlayerResultDto { PlayerId = Guid.NewGuid(), IsWinner = true }
+            }
+        };
+        
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        
+        // Act
+        var act = async () => await _useCase.ExecuteAsync(request);
+        
+        // Assert
+        await act.Should().ThrowAsync<InvalidMatchSessionStateException>();
+    }
+}
+

--- a/tests/Unit/FpsServer.Application.Tests/MatchSession/StartMatchUseCaseTests.cs
+++ b/tests/Unit/FpsServer.Application.Tests/MatchSession/StartMatchUseCaseTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using FpsServer.Application.MatchSession.DTOs;
+using FpsServer.Application.MatchSession.Ports;
+using FpsServer.Application.MatchSession.UseCases;
+using FpsServer.Domain.Matchmaking;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession;
+using FpsServer.Domain.MatchSession.Exceptions;
+using Moq;
+using Xunit;
+
+namespace FpsServer.Application.Tests.MatchSession;
+
+[Trait("Feature", "매치 세션")]
+public class StartMatchUseCaseTests
+{
+    private readonly Mock<IMatchSessionRepository> _repositoryMock;
+    private readonly StartMatchUseCase _useCase;
+    
+    public StartMatchUseCaseTests()
+    {
+        _repositoryMock = new Mock<IMatchSessionRepository>();
+        _useCase = new StartMatchUseCase(_repositoryMock.Object);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 시작 유스케이스")]
+    public async Task 기존_세션이_없으면_새_세션을_생성하고_시작해야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var request = new StartMatchRequest
+        {
+            MatchId = matchId,
+            PlayerIds = playerIds
+        };
+        
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DomainMatchSession?)null);
+        _repositoryMock
+            .Setup(r => r.CreateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _useCase.ExecuteAsync(request, MatchmakingMode.Solo);
+        
+        // Assert
+        result.Should().NotBeNull();
+        result.SessionId.Should().NotBeEmpty();
+        result.Status.Should().Be(MatchStatus.InProgress);
+        
+        _repositoryMock.Verify(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.CreateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 시작 유스케이스")]
+    public async Task 기존_세션이_있으면_재사용하고_시작해야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var request = new StartMatchRequest
+        {
+            MatchId = matchId,
+            PlayerIds = playerIds
+        };
+        
+        var existingSession = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingSession);
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _useCase.ExecuteAsync(request, MatchmakingMode.Solo);
+        
+        // Assert
+        result.Should().NotBeNull();
+        result.SessionId.Should().Be(existingSession.SessionId);
+        result.Status.Should().Be(MatchStatus.InProgress);
+        
+        _repositoryMock.Verify(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.CreateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<DomainMatchSession>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 시작 유스케이스")]
+    public async Task 기존_세션이_이미_시작된_상태이면_InvalidMatchSessionStateException을_발생시켜야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var request = new StartMatchRequest
+        {
+            MatchId = matchId,
+            PlayerIds = playerIds
+        };
+        
+        var existingSession = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        existingSession.Start(); // 이미 시작된 상태
+        
+        _repositoryMock
+            .Setup(r => r.FindByMatchIdAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingSession);
+        
+        // Act
+        var act = async () => await _useCase.ExecuteAsync(request, MatchmakingMode.Solo);
+        
+        // Assert
+        await act.Should().ThrowAsync<InvalidMatchSessionStateException>();
+    }
+}
+

--- a/tests/Unit/FpsServer.Application.Tests/Matchmaking/CancelMatchmakingUseCaseTests.cs
+++ b/tests/Unit/FpsServer.Application.Tests/Matchmaking/CancelMatchmakingUseCaseTests.cs
@@ -3,6 +3,7 @@ using FpsServer.Application.Matchmaking.Ports;
 using FpsServer.Application.Matchmaking.UseCases;
 using FpsServer.Domain.Matchmaking;
 using FpsServer.Domain.Matchmaking.Exceptions;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using Moq;
 using Xunit;
 
@@ -27,7 +28,7 @@ public class CancelMatchmakingUseCaseTests
         // Arrange
         var playerId = Guid.NewGuid();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(request);
         
         _repositoryMock

--- a/tests/Unit/FpsServer.Application.Tests/Matchmaking/JoinMatchmakingQueueUseCaseTests.cs
+++ b/tests/Unit/FpsServer.Application.Tests/Matchmaking/JoinMatchmakingQueueUseCaseTests.cs
@@ -4,6 +4,7 @@ using FpsServer.Application.Matchmaking.Ports;
 using FpsServer.Application.Matchmaking.UseCases;
 using FpsServer.Domain.Matchmaking;
 using DomainMatch = FpsServer.Domain.Matchmaking.Match;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using FpsServer.Domain.Matchmaking.Exceptions;
 using Moq;
 using Xunit;
@@ -87,7 +88,7 @@ public class JoinMatchmakingQueueUseCaseTests
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         
         // 첫 번째 플레이어 큐 진입
-        var player1Request = new PlayerMatchRequest(player1Id, MatchmakingMode.Solo, new MMR(1500));
+        var player1Request = new PlayerMatchRequest(player1Id, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(player1Request);
         
         // 두 번째 플레이어 큐 진입 (매칭 성공)
@@ -125,7 +126,7 @@ public class JoinMatchmakingQueueUseCaseTests
         };
         
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var existingRequest = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var existingRequest = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(existingRequest);
         
         _repositoryMock

--- a/tests/Unit/FpsServer.Domain.Tests/MMR/EloRatingCalculatorTests.cs
+++ b/tests/Unit/FpsServer.Domain.Tests/MMR/EloRatingCalculatorTests.cs
@@ -1,0 +1,215 @@
+using FluentAssertions;
+using FpsServer.Domain.MMR;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+using Xunit;
+
+namespace FpsServer.Domain.Tests.MMR;
+
+[Trait("Feature", "MMR 계산")]
+public class EloRatingCalculatorTests
+{
+    private readonly EloRatingCalculator _calculator;
+
+    public EloRatingCalculatorTests()
+    {
+        _calculator = new EloRatingCalculator();
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 승리_시_MMR이_증가해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1500); // 동일한 MMR
+        var actualScore = 1.0; // 승리
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        newMMR.Value.Should().BeGreaterThan(currentMMR.Value);
+        // 동일한 MMR에서 승리 시 약 16점 증가 (K=32, Expected=0.5, Actual=1.0)
+        newMMR.Value.Should().Be(1516);
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 패배_시_MMR이_감소해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1500); // 동일한 MMR
+        var actualScore = 0.0; // 패배
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        newMMR.Value.Should().BeLessThan(currentMMR.Value);
+        // 동일한 MMR에서 패배 시 약 16점 감소 (K=32, Expected=0.5, Actual=0.0)
+        newMMR.Value.Should().Be(1484);
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 높은_MMR_상대에게_승리하면_큰_폭으로_증가해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1700); // 높은 MMR 상대
+        var actualScore = 1.0; // 승리
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        var mmrIncrease = newMMR.Value - currentMMR.Value;
+        mmrIncrease.Should().BeGreaterThan(16); // 동일 MMR 승리보다 더 큰 증가
+        // Expected Score가 낮으므로 (약 0.24), 실제 점수와의 차이가 커서 더 큰 증가
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 낮은_MMR_상대에게_패배하면_큰_폭으로_감소해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1300); // 낮은 MMR 상대
+        var actualScore = 0.0; // 패배
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        var mmrDecrease = currentMMR.Value - newMMR.Value;
+        mmrDecrease.Should().BeGreaterThan(16); // 동일 MMR 패배보다 더 큰 감소
+        // Expected Score가 높으므로 (약 0.76), 실제 점수와의 차이가 커서 더 큰 감소
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 낮은_MMR_상대에게_승리하면_작은_폭으로_증가해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1300); // 낮은 MMR 상대
+        var actualScore = 1.0; // 승리
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        var mmrIncrease = newMMR.Value - currentMMR.Value;
+        mmrIncrease.Should().BeLessThan(16); // 동일 MMR 승리보다 작은 증가
+        // Expected Score가 높으므로 (약 0.76), 실제 점수와의 차이가 작아서 작은 증가
+    }
+
+    [Fact]
+    [Trait("Category", "Elo 레이팅 계산")]
+    public void 높은_MMR_상대에게_패배하면_작은_폭으로_감소해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1700); // 높은 MMR 상대
+        var actualScore = 0.0; // 패배
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        var mmrDecrease = currentMMR.Value - newMMR.Value;
+        mmrDecrease.Should().BeLessThan(16); // 동일 MMR 패배보다 작은 감소
+        // Expected Score가 낮으므로 (약 0.24), 실제 점수와의 차이가 작아서 작은 감소
+    }
+
+    [Fact]
+    [Trait("Category", "K 값 조정")]
+    public void K_값을_조정하면_증감_폭이_변화해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1500);
+        var actualScore = 1.0; // 승리
+        var kFactor16 = 16;
+        var kFactor32 = 32;
+        var kFactor64 = 64;
+
+        // Act
+        var newMMR16 = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor16);
+        var newMMR32 = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor32);
+        var newMMR64 = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor64);
+
+        // Assert
+        var increase16 = newMMR16.Value - currentMMR.Value;
+        var increase32 = newMMR32.Value - currentMMR.Value;
+        var increase64 = newMMR64.Value - currentMMR.Value;
+
+        increase16.Should().Be(8);  // K=16: 8점 증가
+        increase32.Should().Be(16);  // K=32: 16점 증가
+        increase64.Should().Be(32);  // K=64: 32점 증가
+
+        increase64.Should().BeGreaterThan(increase32);
+        increase32.Should().BeGreaterThan(increase16);
+    }
+
+    [Fact]
+    [Trait("Category", "예외 처리")]
+    public void actualScore가_범위를_벗어나면_ArgumentException을_발생시켜야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1500);
+
+        // Act & Assert
+        var act1 = () => _calculator.CalculateNewMMR(currentMMR, opponentMMR, -0.1, 32);
+        act1.Should().Throw<ArgumentException>()
+            .WithMessage("*Actual score must be between 0.0 and 1.0*");
+
+        var act2 = () => _calculator.CalculateNewMMR(currentMMR, opponentMMR, 1.1, 32);
+        act2.Should().Throw<ArgumentException>()
+            .WithMessage("*Actual score must be between 0.0 and 1.0*");
+    }
+
+    [Fact]
+    [Trait("Category", "예외 처리")]
+    public void kFactor가_0_이하면_ArgumentException을_발생시켜야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(1500);
+        var opponentMMR = new DomainMMR(1500);
+
+        // Act & Assert
+        var act1 = () => _calculator.CalculateNewMMR(currentMMR, opponentMMR, 1.0, 0);
+        act1.Should().Throw<ArgumentException>()
+            .WithMessage("*K factor must be greater than 0*");
+
+        var act2 = () => _calculator.CalculateNewMMR(currentMMR, opponentMMR, 1.0, -1);
+        act2.Should().Throw<ArgumentException>()
+            .WithMessage("*K factor must be greater than 0*");
+    }
+
+    [Fact]
+    [Trait("Category", "MMR 최소값 보장")]
+    public void 계산_결과가_음수가_되면_0으로_보정해야_한다()
+    {
+        // Arrange
+        var currentMMR = new DomainMMR(10); // 낮은 MMR
+        var opponentMMR = new DomainMMR(2000); // 매우 높은 MMR
+        var actualScore = 0.0; // 패배
+        var kFactor = 32;
+
+        // Act
+        var newMMR = _calculator.CalculateNewMMR(currentMMR, opponentMMR, actualScore, kFactor);
+
+        // Assert
+        newMMR.Value.Should().BeGreaterThanOrEqualTo(0);
+    }
+}
+

--- a/tests/Unit/FpsServer.Domain.Tests/MatchSession/MatchSessionTests.cs
+++ b/tests/Unit/FpsServer.Domain.Tests/MatchSession/MatchSessionTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using FpsServer.Domain.Matchmaking;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using FpsServer.Domain.MatchSession;
+using FpsServer.Domain.MatchSession.Exceptions;
+using Xunit;
+
+namespace FpsServer.Domain.Tests.MatchSession;
+
+[Trait("Feature", "매치 세션")]
+public class MatchSessionTests
+{
+    [Fact]
+    [Trait("Category", "매치 세션 생성")]
+    public void 유효한_매개변수가_주어지면_세션을_생성해야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var gameMode = MatchmakingMode.Solo;
+        
+        // Act
+        var session = new DomainMatchSession(matchId, playerIds, gameMode);
+        
+        // Assert
+        session.MatchId.Should().Be(matchId);
+        session.PlayerIds.Should().BeEquivalentTo(playerIds);
+        session.GameMode.Should().Be(gameMode);
+        session.Status.Should().Be(MatchStatus.Matched);
+        session.SessionId.Should().NotBeEmpty();
+        session.StartedAt.Should().BeNull();
+        session.EndedAt.Should().BeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 세션 생성")]
+    public void 빈_매치_ID가_주어지면_ArgumentException을_발생시켜야_한다()
+    {
+        // Arrange
+        var playerIds = new List<Guid> { Guid.NewGuid() };
+        
+        // Act
+        var act = () => new DomainMatchSession(Guid.Empty, playerIds, MatchmakingMode.Solo);
+        
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("matchId");
+    }
+    
+    [Fact]
+    [Trait("Category", "매치 세션 생성")]
+    public void 빈_플레이어_목록이_주어지면_ArgumentException을_발생시켜야_한다()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        
+        // Act
+        var act = () => new DomainMatchSession(matchId, new List<Guid>(), MatchmakingMode.Solo);
+        
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("playerIds");
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void Matched_상태에서_Start를_호출하면_InProgress로_전이해야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        
+        // Act
+        session.Start();
+        
+        // Assert
+        session.Status.Should().Be(MatchStatus.InProgress);
+        session.StartedAt.Should().NotBeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void InProgress_상태가_아니면_Start를_호출할_수_없어야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.Start();
+        session.End(CreateMatchResult(session.MatchId));
+        
+        // Act
+        var act = () => session.Start();
+        
+        // Assert
+        act.Should().Throw<InvalidMatchSessionStateException>()
+            .Which.CurrentStatus.Should().Be(MatchStatus.Finished);
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void InProgress_상태에서_End를_호출하면_Finished로_전이해야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.Start();
+        var result = CreateMatchResult(session.MatchId);
+        
+        // Act
+        session.End(result);
+        
+        // Assert
+        session.Status.Should().Be(MatchStatus.Finished);
+        session.EndedAt.Should().NotBeNull();
+        session.Result.Should().Be(result);
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void InProgress_상태가_아니면_End를_호출할_수_없어야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        var result = CreateMatchResult(session.MatchId);
+        
+        // Act
+        var act = () => session.End(result);
+        
+        // Assert
+        act.Should().Throw<InvalidMatchSessionStateException>()
+            .Which.CurrentStatus.Should().Be(MatchStatus.Matched);
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void End_호출_시_매치_ID가_일치하지_않으면_ArgumentException을_발생시켜야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.Start();
+        var result = CreateMatchResult(Guid.NewGuid()); // 다른 매치 ID
+        
+        // Act
+        var act = () => session.End(result);
+        
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*MatchId mismatch*");
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void Matched_또는_InProgress_상태에서_Cancel을_호출하면_Cancelled로_전이해야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        
+        // Act
+        session.Cancel();
+        
+        // Assert
+        session.Status.Should().Be(MatchStatus.Cancelled);
+        session.EndedAt.Should().NotBeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "상태 전이")]
+    public void Finished_상태에서는_Cancel을_호출할_수_없어야_한다()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.Start();
+        session.End(CreateMatchResult(session.MatchId));
+        
+        // Act
+        var act = () => session.Cancel();
+        
+        // Assert
+        act.Should().Throw<InvalidMatchSessionStateException>()
+            .Which.CurrentStatus.Should().Be(MatchStatus.Finished);
+    }
+    
+    private static DomainMatchSession CreateSession()
+    {
+        return new DomainMatchSession(
+            Guid.NewGuid(),
+            new List<Guid> { Guid.NewGuid(), Guid.NewGuid() },
+            MatchmakingMode.Solo
+        );
+    }
+    
+    private static MatchResult CreateMatchResult(Guid matchId)
+    {
+        var playerResults = new List<PlayerResult>
+        {
+            new PlayerResult(Guid.NewGuid(), true, 100),
+            new PlayerResult(Guid.NewGuid(), false, 50)
+        };
+        
+        return new MatchResult(matchId, playerResults);
+    }
+}
+

--- a/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MMRTests.cs
+++ b/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MMRTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using FpsServer.Domain.Matchmaking;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using Xunit;
 
 namespace FpsServer.Domain.Tests.Matchmaking;
@@ -12,7 +13,7 @@ public class MMRTests
     public void 유효한_값이면_MMR을_생성해야_한다()
     {
         // Arrange & Act
-        var mmr = new MMR(1500);
+        var mmr = new DomainMMR(1500);
         
         // Assert
         mmr.Value.Should().Be(1500);
@@ -23,7 +24,7 @@ public class MMRTests
     public void 음수_값이면_ArgumentException을_발생시켜야_한다()
     {
         // Arrange & Act
-        var act = () => new MMR(-1);
+        var act = () => new DomainMMR(-1);
         
         // Assert
         act.Should().Throw<ArgumentException>()
@@ -36,7 +37,7 @@ public class MMRTests
     public void 영_값이면_MMR을_생성해야_한다()
     {
         // Arrange & Act
-        var mmr = new MMR(0);
+        var mmr = new DomainMMR(0);
         
         // Assert
         mmr.Value.Should().Be(0);
@@ -47,7 +48,7 @@ public class MMRTests
     public void 델타를_더하면_MMR이_증가해야_한다()
     {
         // Arrange
-        var mmr = new MMR(1500);
+        var mmr = new DomainMMR(1500);
         
         // Act
         var result = mmr + 50;
@@ -61,7 +62,7 @@ public class MMRTests
     public void 델타를_빼면_MMR이_감소해야_한다()
     {
         // Arrange
-        var mmr = new MMR(1500);
+        var mmr = new DomainMMR(1500);
         
         // Act
         var result = mmr - 50;
@@ -75,8 +76,8 @@ public class MMRTests
     public void 두_MMR의_차이를_계산하면_정수값을_반환해야_한다()
     {
         // Arrange
-        var mmr1 = new MMR(1500);
-        var mmr2 = new MMR(1450);
+        var mmr1 = new DomainMMR(1500);
+        var mmr2 = new DomainMMR(1450);
         
         // Act
         var result = mmr1 - mmr2;
@@ -90,11 +91,11 @@ public class MMRTests
     public void 두_MMR의_절대_차이를_계산하면_양수값을_반환해야_한다()
     {
         // Arrange
-        var mmr1 = new MMR(1500);
-        var mmr2 = new MMR(1450);
+        var mmr1 = new DomainMMR(1500);
+        var mmr2 = new DomainMMR(1450);
         
         // Act
-        var result = MMR.AbsoluteDifference(mmr1, mmr2);
+        var result = DomainMMR.AbsoluteDifference(mmr1, mmr2);
         
         // Assert
         result.Should().Be(50);
@@ -105,12 +106,12 @@ public class MMRTests
     public void 순서가_바뀌어도_절대_차이는_동일해야_한다()
     {
         // Arrange
-        var mmr1 = new MMR(1500);
-        var mmr2 = new MMR(1450);
+        var mmr1 = new DomainMMR(1500);
+        var mmr2 = new DomainMMR(1450);
         
         // Act
-        var result1 = MMR.AbsoluteDifference(mmr1, mmr2);
-        var result2 = MMR.AbsoluteDifference(mmr2, mmr1);
+        var result1 = DomainMMR.AbsoluteDifference(mmr1, mmr2);
+        var result2 = DomainMMR.AbsoluteDifference(mmr2, mmr1);
         
         // Assert
         result1.Should().Be(50);

--- a/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MatchmakingDomainServiceTests.cs
+++ b/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MatchmakingDomainServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using FpsServer.Domain.Matchmaking;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using Xunit;
 
 namespace FpsServer.Domain.Tests.Matchmaking;
@@ -44,7 +45,7 @@ public class MatchmakingDomainServiceTests
         // Arrange
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(player1);
         
         // Act
@@ -62,8 +63,8 @@ public class MatchmakingDomainServiceTests
         // Arrange
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1550)); // ±100 범위 내
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1550)); // ±100 범위 내
         queue.Enqueue(player1);
         queue.Enqueue(player2);
         
@@ -86,8 +87,8 @@ public class MatchmakingDomainServiceTests
         // Arrange
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1700)); // ±100 범위 밖
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1700)); // ±100 범위 밖
         queue.Enqueue(player1);
         queue.Enqueue(player2);
         
@@ -106,9 +107,9 @@ public class MatchmakingDomainServiceTests
         // Arrange
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1550)); // ±100 범위 내
-        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1700)); // ±100 범위 밖
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1550)); // ±100 범위 내
+        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1700)); // ±100 범위 밖
         queue.Enqueue(player1);
         queue.Enqueue(player2);
         queue.Enqueue(player3);
@@ -133,8 +134,8 @@ public class MatchmakingDomainServiceTests
         // Arrange
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1600)); // 정확히 ±100
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1600)); // 정확히 ±100
         queue.Enqueue(player1);
         queue.Enqueue(player2);
         
@@ -155,9 +156,9 @@ public class MatchmakingDomainServiceTests
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         
         // player1이 먼저 진입, player2는 나중에 진입하지만 MMR이 더 가까움
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1505)); // 더 가까움
-        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1550)); // player1과 매칭 가능
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1505)); // 더 가까움
+        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1550)); // player1과 매칭 가능
         
         queue.Enqueue(player1);
         queue.Enqueue(player2);
@@ -182,10 +183,10 @@ public class MatchmakingDomainServiceTests
         var service = new MatchmakingDomainService();
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         
-        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1550));
-        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1500));
-        var player4 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new MMR(1550));
+        var player1 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player2 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1550));
+        var player3 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1500));
+        var player4 = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Solo, new DomainMMR(1550));
         
         queue.Enqueue(player1);
         queue.Enqueue(player2);

--- a/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MatchmakingQueueTests.cs
+++ b/tests/Unit/FpsServer.Domain.Tests/Matchmaking/MatchmakingQueueTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using FpsServer.Domain.Matchmaking;
 using FpsServer.Domain.Matchmaking.Exceptions;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using Xunit;
 
 namespace FpsServer.Domain.Tests.Matchmaking;
@@ -28,7 +29,7 @@ public class MatchmakingQueueTests
         // Arrange
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         var playerId = Guid.NewGuid();
-        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         
         // Act
         queue.Enqueue(request);
@@ -60,8 +61,8 @@ public class MatchmakingQueueTests
         // Arrange
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         var playerId = Guid.NewGuid();
-        var request1 = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
-        var request2 = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1600));
+        var request1 = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
+        var request2 = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1600));
         
         queue.Enqueue(request1);
         
@@ -79,7 +80,7 @@ public class MatchmakingQueueTests
     {
         // Arrange
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
-        var request = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Duo, new MMR(1500));
+        var request = new PlayerMatchRequest(Guid.NewGuid(), MatchmakingMode.Duo, new DomainMMR(1500));
         
         // Act
         var act = () => queue.Enqueue(request);
@@ -96,7 +97,7 @@ public class MatchmakingQueueTests
         // Arrange
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         var playerId = Guid.NewGuid();
-        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(request);
         
         // Act
@@ -129,7 +130,7 @@ public class MatchmakingQueueTests
         // Arrange
         var queue = new MatchmakingQueue(MatchmakingMode.Solo);
         var playerId = Guid.NewGuid();
-        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(request);
         
         // Act
@@ -165,9 +166,9 @@ public class MatchmakingQueueTests
         var player2 = Guid.NewGuid();
         var player3 = Guid.NewGuid();
         
-        var request1 = new PlayerMatchRequest(player1, MatchmakingMode.Solo, new MMR(1500));
-        var request2 = new PlayerMatchRequest(player2, MatchmakingMode.Solo, new MMR(1600));
-        var request3 = new PlayerMatchRequest(player3, MatchmakingMode.Solo, new MMR(1700));
+        var request1 = new PlayerMatchRequest(player1, MatchmakingMode.Solo, new DomainMMR(1500));
+        var request2 = new PlayerMatchRequest(player2, MatchmakingMode.Solo, new DomainMMR(1600));
+        var request3 = new PlayerMatchRequest(player3, MatchmakingMode.Solo, new DomainMMR(1700));
         
         // Act
         queue.Enqueue(request1);

--- a/tests/Unit/FpsServer.Infrastructure.Tests/FpsServer.Infrastructure.Tests.csproj
+++ b/tests/Unit/FpsServer.Infrastructure.Tests/FpsServer.Infrastructure.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/tests/Unit/FpsServer.Infrastructure.Tests/MMR/EfPlayerMMRRepositoryTests.cs
+++ b/tests/Unit/FpsServer.Infrastructure.Tests/MMR/EfPlayerMMRRepositoryTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using FpsServer.Domain.MMR;
+using FpsServer.Domain.Matchmaking;
+using FpsServer.Infrastructure.MMR;
+using FpsServer.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
+
+namespace FpsServer.Infrastructure.Tests.MMR;
+
+[Trait("Feature", "MMR")]
+public class EfPlayerMMRRepositoryTests
+{
+    private FpsDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<FpsDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new FpsDbContext(options);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByPlayerIdAsync_플레이어ID로_MMR을_조회해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId = Guid.NewGuid();
+        var playerMMR = new PlayerMMR(playerId, new DomainMMR(1500));
+        await context.PlayerMMRs.AddAsync(playerMMR);
+        await context.SaveChangesAsync();
+        
+        // Act
+        var found = await repository.FindByPlayerIdAsync(playerId);
+        
+        // Assert
+        found.Should().NotBeNull();
+        found!.PlayerId.Should().Be(playerId);
+        found.CurrentMMR.Value.Should().Be(1500);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByPlayerIdAsync_존재하지_않는_플레이어면_null을_반환해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        
+        // Act
+        var found = await repository.FindByPlayerIdAsync(Guid.NewGuid());
+        
+        // Assert
+        found.Should().BeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindMultipleByPlayerIdsAsync_여러_플레이어_MMR을_조회해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId1 = Guid.NewGuid();
+        var playerId2 = Guid.NewGuid();
+        var playerId3 = Guid.NewGuid();
+        
+        await context.PlayerMMRs.AddRangeAsync(
+            new PlayerMMR(playerId1, new DomainMMR(1500)),
+            new PlayerMMR(playerId2, new DomainMMR(1600)),
+            new PlayerMMR(playerId3, new DomainMMR(1700)));
+        await context.SaveChangesAsync();
+        
+        // Act
+        var found = await repository.FindMultipleByPlayerIdsAsync(new[] { playerId1, playerId2 });
+        
+        // Assert
+        found.Should().HaveCount(2);
+        found.Select(p => p.PlayerId).Should().Contain(playerId1);
+        found.Select(p => p.PlayerId).Should().Contain(playerId2);
+        found.Select(p => p.PlayerId).Should().NotContain(playerId3);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task SaveAsync_새_플레이어_MMR을_생성해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId = Guid.NewGuid();
+        var playerMMR = new PlayerMMR(playerId, new DomainMMR(1500));
+        
+        // Act
+        await repository.SaveAsync(playerMMR);
+        
+        // Assert
+        var saved = await context.PlayerMMRs.FirstOrDefaultAsync(p => p.PlayerId == playerId);
+        saved.Should().NotBeNull();
+        saved!.CurrentMMR.Value.Should().Be(1500);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task SaveAsync_기존_플레이어_MMR을_업데이트해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId = Guid.NewGuid();
+        var initialMMR = new PlayerMMR(playerId, new DomainMMR(1500));
+        await repository.SaveAsync(initialMMR);
+        
+        // Act
+        initialMMR.UpdateMMR(new DomainMMR(1600));
+        await repository.SaveAsync(initialMMR);
+        
+        // Assert
+        var updated = await context.PlayerMMRs.FirstOrDefaultAsync(p => p.PlayerId == playerId);
+        updated.Should().NotBeNull();
+        updated!.CurrentMMR.Value.Should().Be(1600);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task SaveMultipleAsync_여러_플레이어_MMR을_일괄_저장해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId1 = Guid.NewGuid();
+        var playerId2 = Guid.NewGuid();
+        
+        var playerMMRs = new List<PlayerMMR>
+        {
+            new PlayerMMR(playerId1, new DomainMMR(1500)),
+            new PlayerMMR(playerId2, new DomainMMR(1600))
+        };
+        
+        // Act
+        await repository.SaveMultipleAsync(playerMMRs);
+        
+        // Assert
+        var saved = await context.PlayerMMRs
+            .Where(p => p.PlayerId == playerId1 || p.PlayerId == playerId2)
+            .ToListAsync();
+        saved.Should().HaveCount(2);
+        saved.First(p => p.PlayerId == playerId1).CurrentMMR.Value.Should().Be(1500);
+        saved.First(p => p.PlayerId == playerId2).CurrentMMR.Value.Should().Be(1600);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task SaveMultipleAsync_기존_플레이어와_신규_플레이어를_혼합_저장해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId1 = Guid.NewGuid();
+        var playerId2 = Guid.NewGuid();
+        
+        // 기존 플레이어 1명 생성
+        await repository.SaveAsync(new PlayerMMR(playerId1, new DomainMMR(1500)));
+        
+        // Act
+        var playerMMRs = new List<PlayerMMR>
+        {
+            new PlayerMMR(playerId1, new DomainMMR(1600)), // 업데이트
+            new PlayerMMR(playerId2, new DomainMMR(1700))  // 신규 생성
+        };
+        await repository.SaveMultipleAsync(playerMMRs);
+        
+        // Assert
+        var saved = await context.PlayerMMRs
+            .Where(p => p.PlayerId == playerId1 || p.PlayerId == playerId2)
+            .ToListAsync();
+        saved.Should().HaveCount(2);
+        saved.First(p => p.PlayerId == playerId1).CurrentMMR.Value.Should().Be(1600);
+        saved.First(p => p.PlayerId == playerId2).CurrentMMR.Value.Should().Be(1700);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task MMR_Complex_Type이_제대로_매핑되어야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfPlayerMMRRepository(context);
+        var playerId = Guid.NewGuid();
+        var playerMMR = new PlayerMMR(playerId, new DomainMMR(2000));
+        await repository.SaveAsync(playerMMR);
+        
+        // Act
+        var found = await repository.FindByPlayerIdAsync(playerId);
+        
+        // Assert
+        found.Should().NotBeNull();
+        found!.CurrentMMR.Value.Should().Be(2000);
+        // Complex Type이 제대로 저장되고 조회되는지 검증
+    }
+}
+

--- a/tests/Unit/FpsServer.Infrastructure.Tests/MatchSession/EfMatchSessionRepositoryTests.cs
+++ b/tests/Unit/FpsServer.Infrastructure.Tests/MatchSession/EfMatchSessionRepositoryTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using FpsServer.Domain.Matchmaking;
+using FpsServer.Domain.MatchSession;
+using FpsServer.Infrastructure.MatchSession;
+using FpsServer.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using DomainMatchSession = FpsServer.Domain.MatchSession.MatchSession;
+using Xunit;
+
+namespace FpsServer.Infrastructure.Tests.MatchSession;
+
+[Trait("Feature", "매치 세션")]
+public class EfMatchSessionRepositoryTests
+{
+    private FpsDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<FpsDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new FpsDbContext(options);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task CreateAsync_세션을_생성해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var session = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        
+        // Act
+        await repository.CreateAsync(session);
+        
+        // Assert
+        var saved = await context.MatchSessions.FirstOrDefaultAsync(s => s.SessionId == session.SessionId);
+        saved.Should().NotBeNull();
+        saved!.MatchId.Should().Be(matchId);
+        saved.PlayerIds.Should().BeEquivalentTo(playerIds);
+        saved.GameMode.Should().Be(MatchmakingMode.Solo);
+        saved.Status.Should().Be(MatchStatus.Matched);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByIdAsync_세션ID로_조회해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid() };
+        var session = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        await repository.CreateAsync(session);
+        
+        // Act
+        var found = await repository.FindByIdAsync(session.SessionId);
+        
+        // Assert
+        found.Should().NotBeNull();
+        found!.SessionId.Should().Be(session.SessionId);
+        found.MatchId.Should().Be(matchId);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByIdAsync_존재하지_않는_세션이면_null을_반환해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        
+        // Act
+        var found = await repository.FindByIdAsync(Guid.NewGuid());
+        
+        // Assert
+        found.Should().BeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByMatchIdAsync_매치ID로_조회해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid() };
+        var session = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        await repository.CreateAsync(session);
+        
+        // Act
+        var found = await repository.FindByMatchIdAsync(matchId);
+        
+        // Assert
+        found.Should().NotBeNull();
+        found!.MatchId.Should().Be(matchId);
+        found.SessionId.Should().Be(session.SessionId);
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task FindByMatchIdAsync_존재하지_않는_매치ID면_null을_반환해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        
+        // Act
+        var found = await repository.FindByMatchIdAsync(Guid.NewGuid());
+        
+        // Assert
+        found.Should().BeNull();
+    }
+    
+    [Fact]
+    [Trait("Category", "EF Core 저장소")]
+    public async Task UpdateAsync_세션을_업데이트해야_한다()
+    {
+        // Arrange
+        using var context = CreateDbContext();
+        var repository = new EfMatchSessionRepository(context);
+        var matchId = Guid.NewGuid();
+        var playerIds = new List<Guid> { Guid.NewGuid() };
+        var session = new DomainMatchSession(matchId, playerIds, MatchmakingMode.Solo);
+        await repository.CreateAsync(session);
+        
+        // Act
+        session.Start(); // 상태 전이: Matched → InProgress
+        await repository.UpdateAsync(session);
+        
+        // Assert
+        var updated = await context.MatchSessions.FirstOrDefaultAsync(s => s.SessionId == session.SessionId);
+        updated.Should().NotBeNull();
+        updated!.Status.Should().Be(MatchStatus.InProgress);
+        updated.StartedAt.Should().NotBeNull();
+    }
+}
+

--- a/tests/Unit/FpsServer.Infrastructure.Tests/Matchmaking/InMemoryMatchmakingRepositoryTests.cs
+++ b/tests/Unit/FpsServer.Infrastructure.Tests/Matchmaking/InMemoryMatchmakingRepositoryTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using FpsServer.Domain.Matchmaking;
 using FpsServer.Infrastructure.Matchmaking;
+using DomainMMR = FpsServer.Domain.Matchmaking.MMR;
 using Xunit;
 
 namespace FpsServer.Infrastructure.Tests.Matchmaking;
@@ -61,7 +62,7 @@ public class InMemoryMatchmakingRepositoryTests
         // Arrange
         var queue = await _repository.GetOrCreateQueueAsync(MatchmakingMode.Solo);
         var playerId = Guid.NewGuid();
-        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new MMR(1500));
+        var request = new PlayerMatchRequest(playerId, MatchmakingMode.Solo, new DomainMMR(1500));
         queue.Enqueue(request);
         
         // Act


### PR DESCRIPTION
## Summary

마일스톤 0.5.0 (Match Session & MMR Implementation) 완료  
ADR #15에서 결정한 매치 세션 라이프사이클 및 MMR 시스템 아키텍처를 기반으로 실제 구현을 완료했습니다.  
매칭 성공 후 게임 세션을 시작하고, 종료 시 승/패 결과에 따라 Elo 레이팅 시스템을 사용하여 MMR을 계산 및 업데이트하는 기능을 구현했습니다.

## Includes

* [x] 버전 bump: 0.5.0
* [x] CHANGELOG 업데이트
* [ ] 마이그레이션/주의사항 문서 링크 (있으면)
* [x] 테스트/빌드 통과(링크)
* [x] 관련 이슈:
  * 완료한 이슈: `Resolves #23`, `Resolves #24`, `Resolves #25`, `Resolves #26`
  * 참고 이슈: `related to: #15` (ADR), `related to: #55` (마이그레이션, 마일스톤 0.5.1)

## 주요 변경사항

* 매치 세션 관리 Domain 및 Application 레이어 구현 (#23)
  * `MatchSession` Aggregate Root, `MatchResult`, `PlayerResult` 엔티티 및 값 객체
  * `StartMatchUseCase`, `EndMatchUseCase` 구현
* MMR 계산 및 업데이트 Domain 및 Application 레이어 구현 (#24)
  * `EloRatingCalculator` Domain 서비스 (Elo 레이팅 알고리즘)
  * `PlayerMMR` 엔티티, `UpdatePlayerMMRUseCase`, `BulkUpdatePlayerMMRUseCase` 구현
* 매치 세션 및 MMR 업데이트 API 레이어 구현 (#25)
  * `POST /api/fps/matches/{matchId}/start`, `POST /api/fps/matches/{matchId}/end` 엔드포인트
  * 매치 종료 시 자동 MMR 업데이트 트리거
* 매치 세션 및 MMR Infrastructure 레이어 구현 (#26)
  * `EfMatchSessionRepository`, `EfPlayerMMRRepository` 구현
  * `FpsDbContext` EF Core DbContext 생성 및 엔티티 매핑 설정
  * EF Core In-Memory 통합 테스트 (14개 테스트 모두 통과)

## Deployment Notes

* 대상: prod / staging
* 롤백 플랜: 태그 `0.4.0`으로 롤백 가능
* 영향 범위:
  * 서비스: FPS 게임 서버
  * 엔드포인트: `POST /api/fps/matches/{matchId}/start`, `POST /api/fps/matches/{matchId}/end`
  * DB: 마이그레이션 필요 (#55, 마일스톤 0.5.1에서 진행)
* Smoke Tests:
  - [ ] 매치 시작 API 호출 테스트
  - [ ] 매치 종료 API 호출 테스트
  - [ ] MMR 업데이트 확인
  - [ ] Repository 동작 확인 (마이그레이션 적용 후)

